### PR TITLE
Move sub settings to agent dir

### DIFF
--- a/.changeset/persist-settings-agent-dir.md
+++ b/.changeset/persist-settings-agent-dir.md
@@ -1,0 +1,16 @@
+---
+"@marckrenn/pi-sub-core": patch
+"@marckrenn/pi-sub-bar": patch
+---
+
+Store sub-core and sub-bar settings in agent-level JSON files so updates no longer overwrite user configuration. Legacy extension `settings.json` files are migrated into the new files and removed after a successful migration.
+
+Manual migration (if you want to do it yourself before updating):
+```
+cp ~/.pi/agent/extensions/sub-core/settings.json ~/.pi/agent/pi-sub-core-settings.json
+cp ~/.pi/agent/extensions/sub-bar/settings.json ~/.pi/agent/pi-sub-bar-settings.json
+```
+
+Existing users should move legacy settings from the extension folders to:
+- `~/.pi/agent/pi-sub-core-settings.json`
+- `~/.pi/agent/pi-sub-bar-settings.json`

--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ UI extensions like `sub-bar` listen for updates and render the current provider 
 
 ## Settings & Cache
 
-- **sub-core settings**: `settings.json` next to the sub-core extension entry
-- **sub-bar settings**: `settings.json` next to the sub-bar extension entry
+Settings live in the agent directory to survive updates (legacy extension `settings.json` files are migrated on first run when present, and removed after successful migration):
+
+- **sub-core settings**: `~/.pi/agent/pi-sub-core-settings.json`
+- **sub-bar settings**: `~/.pi/agent/pi-sub-bar-settings.json`
 - **cache**: `cache.json` next to the sub-core extension entry
 - **lock**: `cache.lock` next to the sub-core extension entry
 

--- a/packages/sub-bar/README.md
+++ b/packages/sub-bar/README.md
@@ -110,9 +110,9 @@ The extension loads automatically. Use:
 
 ## Settings
 
-Display and provider UI settings are persisted next to the extension entry (`settings.json` in the same folder as `index.ts`). Core settings are managed by sub-core, and the sub-bar settings menu includes a shortcut that points you to `sub-core:settings` for additional options.
+Display and provider UI settings are stored in `~/.pi/agent/pi-sub-bar-settings.json` (migrated from the legacy extension `settings.json` when present; the legacy file is removed after a successful migration). Core settings are managed by sub-core, and the sub-bar settings menu includes a shortcut that points you to `sub-core:settings` for additional options.
 
-**Settings migrations:** settings are merged with defaults on load, but renames/removals are not migrated automatically. When adding new settings or changing schema, update the defaults/merge logic and provide a migration (or instruct users to reset `settings.json`).
+**Settings migrations:** settings are merged with defaults on load, but renames/removals are not migrated automatically. When adding new settings or changing schema, update the defaults/merge logic and provide a migration (or instruct users to reset `pi-sub-bar-settings.json`).
 
 ### Provider UI Settings
 

--- a/packages/sub-bar/src/paths.ts
+++ b/packages/sub-bar/src/paths.ts
@@ -2,13 +2,20 @@
  * Shared path helpers for sub-bar settings storage.
  */
 
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+const SETTINGS_FILE_NAME = "pi-sub-bar-settings.json";
 
 export function getExtensionDir(): string {
 	return join(dirname(fileURLToPath(import.meta.url)), "..");
 }
 
 export function getSettingsPath(): string {
+	return join(getAgentDir(), SETTINGS_FILE_NAME);
+}
+
+export function getLegacySettingsPath(): string {
 	return join(getExtensionDir(), "settings.json");
 }

--- a/packages/sub-core/README.md
+++ b/packages/sub-core/README.md
@@ -57,7 +57,9 @@ Antigravity usage requires an OAuth token in `~/.pi/agent/auth.json` under the `
 
 Anthropic extra usage formatting is controlled in Provider Settings (currency symbol + decimal separator).
 
-**Settings migrations:** settings are merged with defaults on load, but renames/removals are not migrated automatically. When adding new settings or changing schema, update the defaults/merge logic and provide a migration (or instruct users to reset `settings.json`).
+Settings are stored in `~/.pi/agent/pi-sub-core-settings.json` (migrated from the legacy extension `settings.json` when present; the legacy file is removed after a successful migration).
+
+**Settings migrations:** settings are merged with defaults on load, but renames/removals are not migrated automatically. When adding new settings or changing schema, update the defaults/merge logic and provide a migration (or instruct users to reset `pi-sub-core-settings.json`).
 
 ## Cache
 

--- a/packages/sub-core/src/paths.ts
+++ b/packages/sub-core/src/paths.ts
@@ -2,8 +2,11 @@
  * Shared path helpers for sub-core storage.
  */
 
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+const SETTINGS_FILE_NAME = "pi-sub-core-settings.json";
 
 export function getExtensionDir(): string {
 	return join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -18,5 +21,9 @@ export function getCacheLockPath(): string {
 }
 
 export function getSettingsPath(): string {
+	return join(getAgentDir(), SETTINGS_FILE_NAME);
+}
+
+export function getLegacySettingsPath(): string {
 	return join(getExtensionDir(), "settings.json");
 }

--- a/packages/sub-core/src/settings.ts
+++ b/packages/sub-core/src/settings.ts
@@ -6,18 +6,24 @@ import * as path from "node:path";
 import type { Settings } from "./settings-types.js";
 import { getDefaultSettings, mergeSettings, SETTINGS_VERSION } from "./settings-types.js";
 import { getStorage } from "./storage.js";
-import { getSettingsPath } from "./paths.js";
+import { getLegacySettingsPath, getSettingsPath } from "./paths.js";
 import { clearCache } from "./cache.js";
 
 /**
  * Settings file path
  */
 export const SETTINGS_PATH = getSettingsPath();
+const LEGACY_SETTINGS_PATH = getLegacySettingsPath();
 
 /**
  * In-memory settings cache
  */
 let cachedSettings: Settings | undefined;
+
+type LoadedSettings = {
+	settings: Settings;
+	loadedVersion: number;
+};
 
 /**
  * Ensure the settings directory exists
@@ -28,6 +34,34 @@ function ensureSettingsDir(): void {
 	storage.ensureDir(dir);
 }
 
+function loadSettingsFromDisk(settingsPath: string): LoadedSettings | null {
+	const storage = getStorage();
+	if (!storage.exists(settingsPath)) return null;
+	const content = storage.readFile(settingsPath);
+	if (!content) return null;
+	const loaded = JSON.parse(content) as Partial<Settings>;
+	const loadedVersion = typeof loaded.version === "number" ? loaded.version : 0;
+	const merged = mergeSettings(loaded);
+	return { settings: merged, loadedVersion };
+}
+
+function applyVersionMigration(settings: Settings, loadedVersion: number): { settings: Settings; needsSave: boolean } {
+	if (loadedVersion < SETTINGS_VERSION) {
+		clearCache();
+		return { settings: { ...settings, version: SETTINGS_VERSION }, needsSave: true };
+	}
+	return { settings, needsSave: false };
+}
+
+function tryLoadSettings(settingsPath: string): LoadedSettings | null {
+	try {
+		return loadSettingsFromDisk(settingsPath);
+	} catch (error) {
+		console.error(`Failed to load settings from ${settingsPath}:`, error);
+		return null;
+	}
+}
+
 /**
  * Load settings from disk
  */
@@ -36,25 +70,25 @@ export function loadSettings(): Settings {
 		return cachedSettings;
 	}
 
-	const storage = getStorage();
-	try {
-		if (storage.exists(SETTINGS_PATH)) {
-			const content = storage.readFile(SETTINGS_PATH);
-			if (content) {
-				const loaded = JSON.parse(content) as Partial<Settings>;
-				const loadedVersion = typeof loaded.version === "number" ? loaded.version : 0;
-				const merged = mergeSettings(loaded);
-				if (loadedVersion < SETTINGS_VERSION) {
-					clearCache();
-					merged.version = SETTINGS_VERSION;
-					saveSettings(merged);
-				}
-				cachedSettings = merged;
-				return cachedSettings;
-			}
+	const diskSettings = tryLoadSettings(SETTINGS_PATH);
+	if (diskSettings) {
+		const { settings: next, needsSave } = applyVersionMigration(diskSettings.settings, diskSettings.loadedVersion);
+		if (needsSave) {
+			saveSettings(next);
 		}
-	} catch (error) {
-		console.error(`Failed to load settings from ${SETTINGS_PATH}:`, error);
+		cachedSettings = next;
+		return cachedSettings;
+	}
+
+	const legacySettings = tryLoadSettings(LEGACY_SETTINGS_PATH);
+	if (legacySettings) {
+		const { settings: next } = applyVersionMigration(legacySettings.settings, legacySettings.loadedVersion);
+		const saved = saveSettings(next);
+		if (saved) {
+			getStorage().removeFile(LEGACY_SETTINGS_PATH);
+		}
+		cachedSettings = next;
+		return cachedSettings;
 	}
 
 	// Return defaults if file doesn't exist or failed to load


### PR DESCRIPTION
## Summary\n- store sub-core/sub-bar settings in agent-level files and add legacy migration cleanup\n- update settings documentation and changelog note with manual migration commands\n\n## Testing\n- not run (not requested)