### PR TITLE
Refine theme menu + rename

### DIFF
--- a/.changeset/theme-menu-rename.md
+++ b/.changeset/theme-menu-rename.md
@@ -1,0 +1,5 @@
+---
+"@marckrenn/pi-sub-bar": patch
+---
+
+Refine the theme menu ordering/labels and add rename support for saved themes in the Manage & Load flow.

--- a/packages/sub-bar/src/settings/menu.ts
+++ b/packages/sub-bar/src/settings/menu.ts
@@ -128,21 +128,21 @@ export function buildDisplayThemeMenuItems(): TooltipSelectItem[] {
 	return [
 		{
 			value: "display-theme-save",
-			label: "Save current theme",
+			label: "Save Theme",
 			description: "store current theme",
 			tooltip: "Save the current display theme with a custom name.",
 		},
 		{
-			value: "display-theme-share",
-			label: "Share theme",
-			description: "share without a name",
-			tooltip: "Post a share string for the current theme without a name.",
+			value: "display-theme-load",
+			label: "Manage & Load Themes",
+			description: "load, share, rename and delete themes",
+			tooltip: "Load, share, delete, rename, and restore saved themes.",
 		},
 		{
-			value: "display-theme-load",
-			label: "Manage & Load themes",
-			description: "load, share, delete and restore themes",
-			tooltip: "Load, share, delete, and restore saved themes.",
+			value: "display-theme-share",
+			label: "Share Theme",
+			description: "share current theme",
+			tooltip: "Post a share string for the current theme.",
 		},
 		{
 			value: "display-theme-import",

--- a/packages/sub-bar/src/settings/themes.ts
+++ b/packages/sub-bar/src/settings/themes.ts
@@ -283,6 +283,12 @@ export function buildThemeActionItems(target: DisplayThemeTarget): TooltipSelect
 	];
 	if (target.deletable) {
 		items.push({
+			value: "rename",
+			label: "Rename",
+			description: "rename saved theme",
+			tooltip: "Rename this saved theme.",
+		});
+		items.push({
 			value: "delete",
 			label: "Delete",
 			description: "remove saved theme",
@@ -310,6 +316,28 @@ export function upsertDisplayTheme(
 	} else {
 		settings.displayThemes.push({ id, name: trimmed, display: snapshot, source: resolvedSource });
 	}
+	return settings;
+}
+
+export function renameDisplayTheme(settings: Settings, id: string, name: string): Settings {
+	const trimmed = name.trim() || "Theme";
+	const nextId = buildThemeId(trimmed);
+	const existing = settings.displayThemes.find((theme) => theme.id === id);
+	if (!existing) return settings;
+	if (nextId === id) {
+		existing.name = trimmed;
+		return settings;
+	}
+	const collision = settings.displayThemes.find((theme) => theme.id === nextId);
+	if (collision) {
+		collision.name = trimmed;
+		collision.display = existing.display;
+		collision.source = existing.source;
+		settings.displayThemes = settings.displayThemes.filter((theme) => theme.id !== id);
+		return settings;
+	}
+	existing.id = nextId;
+	existing.name = trimmed;
 	return settings;
 }
 


### PR DESCRIPTION
## Summary\n- reorder and relabel the Theme menu (Save Theme, Manage & Load Themes, Share Theme)\n- rename saved themes from Manage & Load (non-default themes only)\n- update menu/tooltips/title to reflect the Manage & Load naming\n\n## Testing\n- not run (not requested)