### PR TITLE
Default Anthropic extra window off

### DIFF
--- a/.changeset/anthropic-extra-default.md
+++ b/.changeset/anthropic-extra-default.md
@@ -1,0 +1,5 @@
+---
+"@marckrenn/pi-sub-bar": patch
+---
+
+Default Anthropic “Show Extra Window” provider setting to off.

--- a/packages/sub-bar/src/settings-types.ts
+++ b/packages/sub-bar/src/settings-types.ts
@@ -395,7 +395,7 @@ export function getDefaultSettings(): Settings {
 				windows: {
 					show5h: true,
 					show7d: true,
-					showExtra: true,
+					showExtra: false,
 				},
 			},
 			copilot: {


### PR DESCRIPTION
## Summary\n- default Anthropic provider setting for Show Extra Window to off\n\n## Testing\n- not run (not requested)