### PR TITLE
Hang fix + Improve startup responsiveness

### DIFF
--- a/.changeset/release-1-0-5-startup.md
+++ b/.changeset/release-1-0-5-startup.md
@@ -1,0 +1,7 @@
+---
+"@marckrenn/pi-sub-core": patch
+"@marckrenn/pi-sub-bar": patch
+"@marckrenn/pi-sub-shared": patch
+---
+
+Improve startup responsiveness by deferring refreshes and watchers, skipping headless UI work, and unref-ing long-lived timers so pi CLI commands exit cleanly.

--- a/packages/sub-bar/index.ts
+++ b/packages/sub-bar/index.ts
@@ -10,7 +10,7 @@ import * as fs from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ProviderName, ProviderUsageEntry, SubCoreAllState, SubCoreState, UsageSnapshot } from "./src/types.js";
-import type { Settings, BaseTextColor } from "./src/settings-types.js";
+import { getDefaultSettings, type Settings, type BaseTextColor } from "./src/settings-types.js";
 import { isBackgroundColor, resolveBaseTextColor, resolveDividerColor } from "./src/settings-types.js";
 import { buildDividerLine } from "./src/dividers.js";
 import type { CoreSettings } from "@marckrenn/pi-sub-shared";
@@ -69,6 +69,8 @@ const DEFAULT_AGENT_DIR = join(homedir(), ".pi", "agent");
 const PROJECT_SETTINGS_DIR = ".pi";
 const SETTINGS_FILE_NAME = "settings.json";
 
+let scopedModelPatternsCache: { cwd: string; patterns: string[] } | undefined;
+
 function expandTilde(value: string): string {
 	if (value === "~") return homedir();
 	if (value.startsWith("~/")) return join(homedir(), value.slice(2));
@@ -92,6 +94,10 @@ function readPiSettings(path: string): PiSettings | null {
 }
 
 function loadScopedModelPatterns(cwd: string): string[] {
+	if (scopedModelPatternsCache?.cwd === cwd) {
+		return scopedModelPatternsCache.patterns;
+	}
+
 	const globalSettings = readPiSettings(resolveAgentSettingsPath());
 	const projectSettingsPath = join(cwd, PROJECT_SETTINGS_DIR, SETTINGS_FILE_NAME);
 	const projectSettings = readPiSettings(projectSettingsPath);
@@ -106,8 +112,11 @@ function loadScopedModelPatterns(cwd: string): string[] {
 			: [];
 	}
 
-	if (!enabledModels || enabledModels.length === 0) return [];
-	return enabledModels.filter((value) => typeof value === "string");
+	const patterns = !enabledModels || enabledModels.length === 0
+		? []
+		: enabledModels.filter((value) => typeof value === "string");
+	scopedModelPatternsCache = { cwd, patterns };
+	return patterns;
 }
 
 /**
@@ -115,7 +124,8 @@ function loadScopedModelPatterns(cwd: string): string[] {
  */
 export default function createExtension(pi: ExtensionAPI) {
 	let lastContext: ExtensionContext | undefined;
-	let settings: Settings = loadSettings();
+	let settings: Settings = getDefaultSettings();
+	let uiEnabled = true;
 	let currentUsage: UsageSnapshot | undefined;
 	let usageEntries: Partial<Record<ProviderName, UsageSnapshot>> = {};
 	let coreAvailable = false;
@@ -180,7 +190,6 @@ export default function createExtension(pi: ExtensionAPI) {
 		}
 	}
 
-	void ensureSubCoreLoaded();
 
 	async function promptImportAction(ctx: ExtensionContext): Promise<"save-apply" | "save" | "cancel"> {
 		return new Promise((resolve) => {
@@ -431,25 +440,32 @@ export default function createExtension(pi: ExtensionAPI) {
 	function startSettingsWatch(): void {
 		if (settingsWatchStarted) return;
 		settingsWatchStarted = true;
-		const content = readSettingsFile();
-		if (content) {
-			settingsSnapshot = content;
-			try {
-				const stat = fs.statSync(SETTINGS_PATH, { throwIfNoEntry: false });
-				if (stat?.mtimeMs) settingsMtimeMs = stat.mtimeMs;
-			} catch {
-				// Ignore
+		if (!settingsSnapshot) {
+			const content = readSettingsFile();
+			if (content) {
+				settingsSnapshot = content;
+				try {
+					const stat = fs.statSync(SETTINGS_PATH, { throwIfNoEntry: false });
+					if (stat?.mtimeMs) settingsMtimeMs = stat.mtimeMs;
+				} catch {
+					// Ignore
+				}
 			}
 		}
 		try {
 			settingsWatcher = fs.watch(SETTINGS_PATH, scheduleSettingsRefresh);
+			settingsWatcher.unref?.();
 		} catch {
 			settingsWatcher = undefined;
 		}
 		settingsPoll = setInterval(() => checkSettingsFile(), 2000);
+		settingsPoll.unref?.();
 	}
 
 	function renderUsageWidget(ctx: ExtensionContext, usage: UsageSnapshot | undefined, message?: string): void {
+		if (!ctx.hasUI || !uiEnabled) {
+			return;
+		}
 		if (!usage && !message) {
 			ctx.ui.setWidget("usage", undefined);
 			return;
@@ -595,6 +611,13 @@ export default function createExtension(pi: ExtensionAPI) {
 	}
 
 	function updateFetchFailureTicker(): void {
+		if (!uiEnabled) {
+			if (fetchFailureTimer) {
+				clearInterval(fetchFailureTimer);
+				fetchFailureTimer = undefined;
+			}
+			return;
+		}
 		const usage = resolveDisplayedUsage();
 		const shouldTick = Boolean(usage?.error && usage.lastSuccessAt);
 		if (shouldTick && !fetchFailureTimer) {
@@ -602,6 +625,7 @@ export default function createExtension(pi: ExtensionAPI) {
 				if (!lastContext) return;
 				renderCurrent(lastContext);
 			}, 60000);
+			fetchFailureTimer.unref?.();
 		}
 		if (!shouldTick && fetchFailureTimer) {
 			clearInterval(fetchFailureTimer);
@@ -902,37 +926,57 @@ export default function createExtension(pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		lastContext = ctx;
+		uiEnabled = ctx.hasUI;
+		if (!uiEnabled) {
+			return;
+		}
 		settings = loadSettings();
 		coreSettings = getFallbackCoreSettings(settings);
-		const content = readSettingsFile();
-		if (content) {
-			settingsSnapshot = content;
-			try {
-				const stat = fs.statSync(SETTINGS_PATH, { throwIfNoEntry: false });
-				if (stat?.mtimeMs) settingsMtimeMs = stat.mtimeMs;
-			} catch {
-				// Ignore
-			}
-		}
-		const state = await requestCoreState();
-		if (state) {
-			coreAvailable = true;
-			updateUsage(state.usage);
-			if (settings.pinnedProvider) {
-				const entries = await requestCoreEntries();
-				updateEntries(entries);
-				if (lastContext) {
-					renderCurrent(lastContext);
+		if (!settingsSnapshot) {
+			const content = readSettingsFile();
+			if (content) {
+				settingsSnapshot = content;
+				try {
+					const stat = fs.statSync(SETTINGS_PATH, { throwIfNoEntry: false });
+					if (stat?.mtimeMs) settingsMtimeMs = stat.mtimeMs;
+				} catch {
+					// Ignore
 				}
 			}
-		} else if (lastContext) {
-			coreAvailable = false;
-			renderCurrent(lastContext);
 		}
+
+		const watchTimer = setTimeout(() => startSettingsWatch(), 0);
+		watchTimer.unref?.();
+
+		const sessionContext = ctx;
+		void (async () => {
+			await ensureSubCoreLoaded();
+			if (!lastContext || lastContext !== sessionContext || !uiEnabled) return;
+			const state = await requestCoreState();
+			if (!lastContext || lastContext !== sessionContext || !uiEnabled) return;
+			if (state) {
+				coreAvailable = true;
+				updateUsage(state.usage);
+				if (settings.pinnedProvider) {
+					const entries = await requestCoreEntries();
+					if (!lastContext || lastContext !== sessionContext || !uiEnabled) return;
+					updateEntries(entries);
+					if (lastContext) {
+						renderCurrent(lastContext);
+					}
+				}
+			} else if (lastContext && !coreAvailable) {
+				coreAvailable = false;
+				renderCurrent(lastContext);
+			}
+		})();
 	});
 
 	pi.on("model_select" as unknown as "session_start", async (_event: unknown, ctx: ExtensionContext) => {
 		lastContext = ctx;
+		if (!uiEnabled || !ctx.hasUI) {
+			return;
+		}
 		if (currentUsage) {
 			renderUsageWidget(ctx, currentUsage);
 		}
@@ -946,5 +990,4 @@ export default function createExtension(pi: ExtensionAPI) {
 		}
 	});
 
-	startSettingsWatch();
 }

--- a/packages/sub-core/index.ts
+++ b/packages/sub-core/index.ts
@@ -5,7 +5,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import type { Dependencies, ProviderName, SubCoreState, UsageSnapshot } from "./src/types.js";
-import type { Settings } from "./src/settings-types.js";
+import { getDefaultSettings, type Settings } from "./src/settings-types.js";
 import type { ProviderUsageEntry } from "./src/usage/types.js";
 import { createDefaultDependencies } from "./src/dependencies.js";
 import { createUsageController, type UsageUpdate } from "./src/usage/controller.js";
@@ -85,8 +85,11 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 	let lastContext: ExtensionContext | undefined;
 	let lastUsageRefreshAt = 0;
 	let lastStatusRefreshAt = 0;
-	let settings: Settings = loadSettings();
+	let settings: Settings = getDefaultSettings();
+	let settingsLoaded = false;
+	let toolsRegistered = false;
 	let lastState: SubCoreState = {};
+	let shouldSkipNextModelSelectFetch = true;
 
 	const controller = createUsageController(deps);
 	const controllerState = {
@@ -133,31 +136,51 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 		emitCurrentUpdate(controllerState.currentProvider, usage);
 	});
 
-	const stopCacheWatch = watchCacheUpdates();
+	let stopCacheWatch: (() => void) | undefined;
+	let cacheWatchStarted = false;
+
+	const startCacheWatch = (): void => {
+		if (cacheWatchStarted) return;
+		cacheWatchStarted = true;
+		stopCacheWatch = watchCacheUpdates();
+	};
 
 	function emitUpdate(update: UsageUpdate): void {
 		emitCurrentUpdate(update.provider, update.usage);
 	}
 
-	async function refresh(ctx: ExtensionContext, options?: { force?: boolean; allowStaleCache?: boolean }) {
+	async function refresh(
+		ctx: ExtensionContext,
+		options?: { force?: boolean; allowStaleCache?: boolean; skipFetch?: boolean }
+	) {
 		lastContext = ctx;
+		ensureSettingsLoaded();
 		try {
 			await controller.refresh(ctx, settings, controllerState, emitUpdate, options);
 		} finally {
-			lastUsageRefreshAt = Date.now();
+			if (!options?.skipFetch) {
+				lastUsageRefreshAt = Date.now();
+			}
 		}
 	}
 
-	async function refreshStatus(ctx: ExtensionContext, options?: { force?: boolean; allowStaleCache?: boolean }) {
+	async function refreshStatus(
+		ctx: ExtensionContext,
+		options?: { force?: boolean; allowStaleCache?: boolean; skipFetch?: boolean }
+	) {
 		lastContext = ctx;
+		ensureSettingsLoaded();
 		try {
 			await controller.refreshStatus(ctx, settings, controllerState, emitUpdate, options);
 		} finally {
-			lastStatusRefreshAt = Date.now();
+			if (!options?.skipFetch) {
+				lastStatusRefreshAt = Date.now();
+			}
 		}
 	}
 
 	async function cycleProvider(ctx: ExtensionContext): Promise<void> {
+		ensureSettingsLoaded();
 		await controller.cycleProvider(ctx, settings, controllerState, emitUpdate);
 	}
 
@@ -181,6 +204,7 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 					void refresh(lastContext);
 				}
 			}, usageTickMs);
+			usageRefreshInterval.unref?.();
 		}
 
 		const statusIntervalMs = settings.statusRefresh.refreshInterval * 1000;
@@ -193,10 +217,12 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 					void refreshStatus(lastContext);
 				}
 			}, statusTickMs);
+			statusRefreshInterval.unref?.();
 		}
 	}
 
 	function applySettingsPatch(patch: Partial<Settings>): void {
+		ensureSettingsLoaded();
 		settings = deepMerge(settings, patch);
 		saveSettings(settings);
 		setupRefreshInterval();
@@ -204,6 +230,7 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 	}
 
 	async function getEntries(force?: boolean): Promise<ProviderUsageEntry[]> {
+		ensureSettingsLoaded();
 		const enabledProviders = controller.getEnabledProviders(settings);
 		if (enabledProviders.length === 0) return [];
 		if (force) {
@@ -255,22 +282,37 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 		});
 	};
 
-	const usageToolEnabled = settings.tools?.usageTool ?? false;
-	const allUsageToolEnabled = settings.tools?.allUsageTool ?? false;
+	function registerToolsFromSettings(nextSettings: Settings): void {
+		if (toolsRegistered) return;
+		const usageToolEnabled = nextSettings.tools?.usageTool ?? false;
+		const allUsageToolEnabled = nextSettings.tools?.allUsageTool ?? false;
 
-	if (usageToolEnabled) {
-		for (const name of TOOL_NAMES.usage) {
-			registerUsageTool(name);
+		if (usageToolEnabled) {
+			for (const name of TOOL_NAMES.usage) {
+				registerUsageTool(name);
+			}
 		}
+		if (allUsageToolEnabled) {
+			for (const name of TOOL_NAMES.allUsage) {
+				registerAllUsageTool(name);
+			}
+		}
+		toolsRegistered = true;
 	}
-	if (allUsageToolEnabled) {
-		for (const name of TOOL_NAMES.allUsage) {
-			registerAllUsageTool(name);
-		}
+
+	function ensureSettingsLoaded(): void {
+		if (settingsLoaded) return;
+		settings = loadSettings();
+		settingsLoaded = true;
+		registerToolsFromSettings(settings);
+		setupRefreshInterval();
+		const watchTimer = setTimeout(() => startCacheWatch(), 0);
+		watchTimer.unref?.();
 	}
 	pi.registerCommand("sub-core:settings", {
 		description: "Open sub-core settings",
 		handler: async (_args, ctx) => {
+			ensureSettingsLoaded();
 			const handleSettingsChange = async (updatedSettings: Settings) => {
 				applySettingsPatch(updatedSettings);
 				if (lastContext) {
@@ -288,6 +330,7 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 	});
 
 	pi.events.on("sub-core:request", async (payload) => {
+		ensureSettingsLoaded();
 		const request = payload as SubCoreRequest;
 		if (request.type === "entries") {
 			const entries = await getEntries(request.force);
@@ -327,10 +370,10 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 
 	pi.on("session_start", async (_event, ctx) => {
 		lastContext = ctx;
-		settings = loadSettings();
-		setupRefreshInterval();
-		void refresh(ctx, { force: true, allowStaleCache: true });
-		void refreshStatus(ctx, { force: true, allowStaleCache: true });
+		shouldSkipNextModelSelectFetch = true;
+		ensureSettingsLoaded();
+		void refresh(ctx, { allowStaleCache: true, skipFetch: true });
+		void refreshStatus(ctx, { allowStaleCache: true, skipFetch: true });
 		pi.events.emit("sub-core:ready", { state: lastState, settings });
 	});
 
@@ -373,6 +416,12 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 	pi.on("model_select" as unknown as "session_start", async (_event: unknown, ctx: ExtensionContext) => {
 		controllerState.currentProvider = undefined;
 		controllerState.cachedUsage = undefined;
+		if (shouldSkipNextModelSelectFetch) {
+			shouldSkipNextModelSelectFetch = false;
+			void refresh(ctx, { allowStaleCache: true, skipFetch: true });
+			void refreshStatus(ctx, { allowStaleCache: true, skipFetch: true });
+			return;
+		}
 		void refresh(ctx, { force: true, allowStaleCache: true });
 		void refreshStatus(ctx, { force: true, allowStaleCache: true });
 	});
@@ -388,7 +437,9 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 		}
 		unsubscribeCache();
 		unsubscribeCacheSnapshot();
-		stopCacheWatch();
+		stopCacheWatch?.();
+		stopCacheWatch = undefined;
+		cacheWatchStarted = false;
 		lastContext = undefined;
 		subCoreGlobal.__piSubCore = undefined;
 	});

--- a/packages/sub-core/src/cache.ts
+++ b/packages/sub-core/src/cache.ts
@@ -295,11 +295,13 @@ export function watchCacheUpdates(options?: CacheWatchOptions): () => void {
 	let watcher: fs.FSWatcher | undefined;
 	try {
 		watcher = fs.watch(CACHE_PATH, scheduleEmit);
+		watcher.unref?.();
 	} catch {
 		watcher = undefined;
 	}
 
 	pollTimer = setInterval(() => emitFromCache(), pollIntervalMs);
+	pollTimer.unref?.();
 
 	return () => {
 		stopped = true;

--- a/packages/sub-core/src/usage/controller.ts
+++ b/packages/sub-core/src/usage/controller.ts
@@ -28,10 +28,15 @@ export interface UsageUpdate {
 export type UsageUpdateHandler = (update: UsageUpdate) => void;
 
 export function createUsageController(deps: Dependencies) {
-	function isProviderAvailable(settings: Settings, provider: ProviderName): boolean {
+	function isProviderAvailable(
+		settings: Settings,
+		provider: ProviderName,
+		options?: { skipCredentials?: boolean }
+	): boolean {
 		const setting = settings.providers[provider];
 		if (setting.enabled === "off" || setting.enabled === false) return false;
 		if (setting.enabled === "on" || setting.enabled === true) return true;
+		if (options?.skipCredentials) return true;
 		return hasProviderCredentials(provider, deps);
 	}
 
@@ -42,10 +47,11 @@ export function createUsageController(deps: Dependencies) {
 	function resolveProvider(
 		ctx: ExtensionContext,
 		settings: Settings,
-		state: UsageControllerState
+		state: UsageControllerState,
+		options?: { skipCredentials?: boolean }
 	): ProviderName | undefined {
 		const detected = detectProviderFromModel(ctx.model);
-		if (detected && isProviderAvailable(settings, detected)) {
+		if (detected && isProviderAvailable(settings, detected, options)) {
 			return detected;
 		}
 		return undefined;
@@ -63,9 +69,9 @@ export function createUsageController(deps: Dependencies) {
 		settings: Settings,
 		state: UsageControllerState,
 		onUpdate: UsageUpdateHandler,
-		options?: { force?: boolean; allowStaleCache?: boolean; forceStatus?: boolean }
+		options?: { force?: boolean; allowStaleCache?: boolean; forceStatus?: boolean; skipFetch?: boolean }
 	): Promise<void> {
-		const provider = resolveProvider(ctx, settings, state);
+		const provider = resolveProvider(ctx, settings, state, { skipCredentials: options?.skipFetch });
 		if (!provider) {
 			state.currentProvider = undefined;
 			state.cachedUsage = undefined;
@@ -95,6 +101,10 @@ export function createUsageController(deps: Dependencies) {
 			}
 		}
 		emitUpdate(state, onUpdate);
+
+		if (options?.skipFetch) {
+			return;
+		}
 
 		const result = await fetchUsageForProvider(deps, settings, provider, options);
 		const error = result.usage?.error;
@@ -138,9 +148,9 @@ export function createUsageController(deps: Dependencies) {
 		settings: Settings,
 		state: UsageControllerState,
 		onUpdate: UsageUpdateHandler,
-		options?: { force?: boolean; allowStaleCache?: boolean }
+		options?: { force?: boolean; allowStaleCache?: boolean; skipFetch?: boolean }
 	): Promise<void> {
-		const provider = resolveProvider(ctx, settings, state);
+		const provider = resolveProvider(ctx, settings, state, { skipCredentials: options?.skipFetch });
 		if (!provider) {
 			state.currentProvider = undefined;
 			state.cachedUsage = undefined;
@@ -168,6 +178,11 @@ export function createUsageController(deps: Dependencies) {
 			if (!cachedEntry.usage.error) {
 				state.lastSuccessAt = cachedEntry.fetchedAt;
 			}
+		}
+
+		if (options?.skipFetch) {
+			emitUpdate(state, onUpdate);
+			return;
 		}
 
 		const status = await refreshStatusForProvider(deps, settings, provider, { force: options?.force });


### PR DESCRIPTION
# Summary
- Prevent CLI hangs by unref-ing long-lived timers/watchers in sub-core and sub-bar.
- Make startup cache-first: skip initial usage/status fetches (and credential checks) and skip the first model_select fetch.
- Defer cache/settings watchers to post-session_start, lazy-load sub-core settings/tools, and avoid headless UI work.
- Cache enabledModels per cwd and avoid duplicate settings reads.