### PR TITLE
Release 1.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ node_modules
 *.log
 *.tsbuildinfo
 
+# pi project-local installs
+.pi/
+
+# packed artifacts
+*.tgz
+
 packages/sub-bar/settings.json
 packages/sub-core/settings.json
 

--- a/packages/sub-bar/.npmignore
+++ b/packages/sub-bar/.npmignore
@@ -1,0 +1,15 @@
+# never ship packed artifacts
+*.tgz
+
+# local install artifacts
+node_modules
+package-lock.json
+
+# local dev files
+settings.json
+.DS_Store
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/sub-bar/CHANGELOG.md
+++ b/packages/sub-bar/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @marckrenn/pi-sub-bar
 
+## 1.0.6
+
+### Patch Changes
+
+- Remove `bundleDependencies`/`bundledDependencies` from `@marckrenn/pi-sub-bar` to fix `npm install -g @marckrenn/pi-sub-bar` failing with `protobufjs` postinstall (missing `scripts/postinstall.js`) on Node 24+/npm.
+
+  Also include a second extension path (`../pi-sub-core/index.ts`) so `sub-core` is discovered whether npm installs `@marckrenn/pi-sub-core` nested or hoisted, restoring `/sub-core:settings`.
+
+- Updated dependencies []:
+  - @marckrenn/pi-sub-core@1.0.6
+  - @marckrenn/pi-sub-shared@1.0.6
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/sub-bar/package.json
+++ b/packages/sub-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marckrenn/pi-sub-bar",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Usage widget extension for pi-coding-agent - shows current provider usage above the editor",
   "keywords": [
     "pi-package"
@@ -14,15 +14,15 @@
   "pi": {
     "extensions": [
       "./index.ts",
-      "node_modules/@marckrenn/pi-sub-core/index.ts"
+      "node_modules/@marckrenn/pi-sub-core/index.ts",
+      "../pi-sub-core/index.ts"
     ]
   },
   "scripts": {
     "check": "tsc --noEmit",
     "check:watch": "tsc --noEmit --watch",
     "test": "tsx test/all.test.ts",
-    "test:watch": "tsx watch test/all.test.ts",
-    "prepack": "npm install --workspaces=false --omit=dev --no-package-lock"
+    "test:watch": "tsx watch test/all.test.ts"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -30,16 +30,10 @@
     "typescript": "^5.8.0"
   },
   "dependencies": {
-    "@marckrenn/pi-sub-core": "^1.0.5",
-    "@marckrenn/pi-sub-shared": "^1.0.5"
+    "@marckrenn/pi-sub-core": "^1.0.6",
+    "@marckrenn/pi-sub-shared": "^1.0.6"
   },
-  "bundledDependencies": [
-    "@marckrenn/pi-sub-core"
-  ],
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*"
-  },
-  "bundleDependencies": [
-    "@marckrenn/pi-sub-core"
-  ]
+  }
 }

--- a/packages/sub-core/CHANGELOG.md
+++ b/packages/sub-core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @marckrenn/pi-sub-core
 
+## 1.0.6
+
+### Patch Changes
+
+- Watch `~/.pi/agent/pi-sub-core-settings.json` for changes and hot-reload settings (with `fs.watch` + polling fallback).
+
+- Updated dependencies []:
+  - @marckrenn/pi-sub-shared@1.0.6
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/sub-core/index.ts
+++ b/packages/sub-core/index.ts
@@ -4,6 +4,7 @@
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
+import * as fs from "node:fs";
 import type { Dependencies, ProviderName, SubCoreState, UsageSnapshot } from "./src/types.js";
 import { getDefaultSettings, type Settings } from "./src/settings-types.js";
 import type { ProviderUsageEntry } from "./src/usage/types.js";
@@ -13,7 +14,7 @@ import { fetchUsageEntries, getCachedUsageEntries } from "./src/usage/fetch.js";
 import { onCacheSnapshot, onCacheUpdate, watchCacheUpdates, type Cache } from "./src/cache.js";
 import { isExpectedMissingData } from "./src/errors.js";
 import { getStorage } from "./src/storage.js";
-import { loadSettings, saveSettings } from "./src/settings.js";
+import { clearSettingsCache, loadSettings, saveSettings, SETTINGS_PATH } from "./src/settings.js";
 import { showSettingsUI } from "./src/settings-ui.js";
 
 type SubCoreRequest =
@@ -90,6 +91,12 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 	let toolsRegistered = false;
 	let lastState: SubCoreState = {};
 	let shouldSkipNextModelSelectFetch = true;
+	let settingsSnapshot = "";
+	let settingsMtimeMs = 0;
+	let settingsDebounce: NodeJS.Timeout | undefined;
+	let settingsWatcher: fs.FSWatcher | undefined;
+	let settingsPoll: NodeJS.Timeout | undefined;
+	let settingsWatchStarted = false;
 
 	const controller = createUsageController(deps);
 	const controllerState = {
@@ -229,6 +236,80 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 		pi.events.emit("sub-core:settings:updated", { settings });
 	}
 
+	function readSettingsFile(): string | undefined {
+		try {
+			return fs.readFileSync(SETTINGS_PATH, "utf-8");
+		} catch {
+			return undefined;
+		}
+	}
+
+	function applySettingsFromDisk(): void {
+		clearSettingsCache();
+		settings = loadSettings();
+		registerToolsFromSettings(settings);
+		setupRefreshInterval();
+		pi.events.emit("sub-core:settings:updated", { settings });
+		if (lastContext) {
+			void refresh(lastContext, { allowStaleCache: true, skipFetch: true });
+			void refreshStatus(lastContext, { allowStaleCache: true, skipFetch: true });
+		}
+	}
+
+	function refreshSettingsSnapshot(): void {
+		const content = readSettingsFile();
+		if (!content || content === settingsSnapshot) return;
+		try {
+			JSON.parse(content);
+		} catch {
+			return;
+		}
+		settingsSnapshot = content;
+		applySettingsFromDisk();
+	}
+
+	function checkSettingsFile(): void {
+		try {
+			const stat = fs.statSync(SETTINGS_PATH, { throwIfNoEntry: false });
+			if (!stat || !stat.mtimeMs) return;
+			if (stat.mtimeMs === settingsMtimeMs) return;
+			settingsMtimeMs = stat.mtimeMs;
+			refreshSettingsSnapshot();
+		} catch {
+			// Ignore missing files
+		}
+	}
+
+	function scheduleSettingsRefresh(): void {
+		if (settingsDebounce) clearTimeout(settingsDebounce);
+		settingsDebounce = setTimeout(() => checkSettingsFile(), 200);
+	}
+
+	function startSettingsWatch(): void {
+		if (settingsWatchStarted) return;
+		settingsWatchStarted = true;
+		if (!settingsSnapshot) {
+			const content = readSettingsFile();
+			if (content) {
+				settingsSnapshot = content;
+				try {
+					const stat = fs.statSync(SETTINGS_PATH, { throwIfNoEntry: false });
+					if (stat?.mtimeMs) settingsMtimeMs = stat.mtimeMs;
+				} catch {
+					// Ignore
+				}
+			}
+		}
+		try {
+			settingsWatcher = fs.watch(SETTINGS_PATH, scheduleSettingsRefresh);
+			settingsWatcher.unref?.();
+		} catch {
+			settingsWatcher = undefined;
+		}
+		settingsPoll = setInterval(() => checkSettingsFile(), 2000);
+		settingsPoll.unref?.();
+	}
+
 	async function getEntries(force?: boolean): Promise<ProviderUsageEntry[]> {
 		ensureSettingsLoaded();
 		const enabledProviders = controller.getEnabledProviders(settings);
@@ -306,7 +387,10 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 		settingsLoaded = true;
 		registerToolsFromSettings(settings);
 		setupRefreshInterval();
-		const watchTimer = setTimeout(() => startCacheWatch(), 0);
+		const watchTimer = setTimeout(() => {
+			startCacheWatch();
+			startSettingsWatch();
+		}, 0);
 		watchTimer.unref?.();
 	}
 	pi.registerCommand("sub-core:settings", {
@@ -435,6 +519,19 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 			clearInterval(statusRefreshInterval);
 			statusRefreshInterval = undefined;
 		}
+		if (settingsDebounce) {
+			clearTimeout(settingsDebounce);
+			settingsDebounce = undefined;
+		}
+		if (settingsPoll) {
+			clearInterval(settingsPoll);
+			settingsPoll = undefined;
+		}
+		settingsWatcher?.close();
+		settingsWatcher = undefined;
+		settingsWatchStarted = false;
+		settingsSnapshot = "";
+		settingsMtimeMs = 0;
 		unsubscribeCache();
 		unsubscribeCacheSnapshot();
 		stopCacheWatch?.();

--- a/packages/sub-core/package.json
+++ b/packages/sub-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marckrenn/pi-sub-core",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Shared usage data core for pi extensions",
   "keywords": [
     "pi-package"
@@ -27,7 +27,7 @@
     "typescript": "^5.8.0"
   },
   "dependencies": {
-    "@marckrenn/pi-sub-shared": "^1.0.5"
+    "@marckrenn/pi-sub-shared": "^1.0.6"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "*"

--- a/packages/sub-shared/CHANGELOG.md
+++ b/packages/sub-shared/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @marckrenn/pi-sub-shared
 
+## 1.0.6
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/sub-shared/package.json
+++ b/packages/sub-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marckrenn/pi-sub-shared",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Shared types and event contract for the sub-* ecosystem",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
 ## Summary

 This PR prepares the 1.0.6 release of the pi-sub packages and addresses two issues reported by users:

 1. Fix pi install npm:@marckrenn/pi-sub-bar / npm install -g @marckrenn/pi-sub-bar failing on Node 24+/npm with:
     - protobufjs postinstall error (Cannot find module .../protobufjs/scripts/postinstall)
 2. Restore /sub-core:settings availability when installing sub-bar (sub-core wasn’t being discovered in some npm layouts).
 3. Add sub-core settings hot-reload: watch ~/.pi/agent/pi-sub-core-settings.json and apply changes live (fs.watch + polling
 fallback).

 ## Changes

 - @marckrenn/pi-sub-bar
     - Removed bundleDependencies/bundledDependencies (no more shipping node_modules in the tarball).
     - Added a second extension path so sub-core is loaded whether npm installs it nested or hoisted:
           - node_modules/@marckrenn/pi-sub-core/index.ts
           - ../pi-sub-core/index.ts
     - Added .npmignore to avoid publishing local artifacts (node_modules, *.tgz, etc.).
 - @marckrenn/pi-sub-core
     - Added settings file watch + hot-reload for SETTINGS_PATH (debounced fs.watch + polling fallback).
     - Updated changelog entry accordingly.
 - Versioning
     - Bumped fixed group to 1.0.6 (sub-bar, sub-core, sub-shared) via Changesets.

 ## Verification

 - npm test (all workspaces) ✅
 - npm run check ✅
 - Local reproduction:
     - npm i -g --prefix /tmp/... <packed-tgz> succeeds
     - pi -e "npm:@marckrenn/pi-sub-bar@file:<tgz>" and /sub-core:settings works