### PR TITLE
sub-bar: Make keybindings configurable

### DIFF
--- a/.changeset/sparkly-toys-report.md
+++ b/.changeset/sparkly-toys-report.md
@@ -1,0 +1,5 @@
+---
+'@marckrenn/pi-sub-bar': minor
+---
+
+Make keybindings configurable

--- a/packages/sub-bar/README.md
+++ b/packages/sub-bar/README.md
@@ -94,8 +94,12 @@ The extension loads automatically. Use:
 - `sub-bar:settings` - Open display + provider UI settings (includes Provider Shown)
 - `sub-bar:import <share string>` - Preview a shared theme and choose to save/apply
 - `sub-core:settings` - Configure provider enablement/order + usage/status refresh settings
-- `Ctrl+Alt+P` - Cycle through available providers
-- `Ctrl+Alt+R` - Toggle reset timer format (relative vs datetime)
+- `Ctrl+Alt+P` - Cycle through available providers (configurable)
+- `Ctrl+Alt+R` - Toggle reset timer format (configurable)
+
+**Keybindings:**
+
+Shortcuts are configurable via `sub-bar:settings` → Keybindings. Enter any valid key combo (e.g. `ctrl+alt+p`, `ctrl+shift+s`) or `none` to disable a shortcut. Keybinding changes take effect after pi restart.
 
 **Caching:**
 - Handled by sub-core at `~/.pi/agent/cache/sub-core/cache.json`

--- a/packages/sub-bar/index.ts
+++ b/packages/sub-bar/index.ts
@@ -10,10 +10,11 @@ import * as fs from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ProviderName, ProviderUsageEntry, SubCoreAllState, SubCoreState, UsageSnapshot } from "./src/types.js";
-import { getDefaultSettings, type Settings, type BaseTextColor } from "./src/settings-types.js";
+import { type Settings, type BaseTextColor } from "./src/settings-types.js";
 import { isBackgroundColor, resolveBaseTextColor, resolveDividerColor } from "./src/settings-types.js";
 import { buildDividerLine } from "./src/dividers.js";
 import type { CoreSettings } from "@marckrenn/pi-sub-shared";
+import type { KeyId } from "@mariozechner/pi-tui";
 import { formatUsageStatus, formatUsageStatusWithWidth } from "./src/formatting.js";
 import { clearSettingsCache, loadSettings, saveSettings, SETTINGS_PATH } from "./src/settings.js";
 import { showSettingsUI } from "./src/settings-ui.js";
@@ -124,7 +125,7 @@ function loadScopedModelPatterns(cwd: string): string[] {
  */
 export default function createExtension(pi: ExtensionAPI) {
 	let lastContext: ExtensionContext | undefined;
-	let settings: Settings = getDefaultSettings();
+	let settings: Settings = loadSettings();
 	let uiEnabled = true;
 	let currentUsage: UsageSnapshot | undefined;
 	let usageEntries: Partial<Record<ProviderName, UsageSnapshot>> = {};
@@ -399,6 +400,7 @@ export default function createExtension(pi: ExtensionAPI) {
 			displayThemes: loaded.displayThemes,
 			displayUserTheme: loaded.displayUserTheme,
 			pinnedProvider: loaded.pinnedProvider,
+			keybindings: loaded.keybindings,
 		};
 		coreSettings = getFallbackCoreSettings(settings);
 		updateFetchFailureTicker();
@@ -547,7 +549,7 @@ export default function createExtension(pi: ExtensionAPI) {
 			}),
 			{ placement: settings.display.widgetPlacement ?? "belowEditor" },
 		);
-		
+
 	}
 
 	function resolveDisplayedUsage(): UsageSnapshot | undefined {
@@ -905,24 +907,30 @@ export default function createExtension(pi: ExtensionAPI) {
 	});
 
 	// Register shortcut to cycle providers
-	pi.registerShortcut("ctrl+alt+p", {
-		description: "Cycle usage provider",
-		handler: async () => {
-			emitCoreAction({ type: "cycleProvider" });
-		},
-	});
+	const cycleProviderKey = settings.keybindings?.cycleProvider || "ctrl+alt+p";
+	if (cycleProviderKey !== "none") {
+		pi.registerShortcut(cycleProviderKey as KeyId, {
+			description: "Cycle usage provider",
+			handler: async () => {
+				emitCoreAction({ type: "cycleProvider" });
+			},
+		});
+	}
 
 	// Register shortcut to toggle reset timer format
-	pi.registerShortcut("ctrl+alt+r", {
-		description: "Toggle reset timer format",
-		handler: async () => {
-			settings.display.resetTimeFormat = settings.display.resetTimeFormat === "datetime" ? "relative" : "datetime";
-			saveSettings(settings);
-			if (lastContext && currentUsage) {
-				renderUsageWidget(lastContext, currentUsage);
-			}
-		},
-	});
+	const toggleResetFormatKey = settings.keybindings?.toggleResetFormat || "ctrl+alt+r";
+	if (toggleResetFormatKey !== "none") {
+		pi.registerShortcut(toggleResetFormatKey as KeyId, {
+			description: "Toggle reset timer format",
+			handler: async () => {
+				settings.display.resetTimeFormat = settings.display.resetTimeFormat === "datetime" ? "relative" : "datetime";
+				saveSettings(settings);
+				if (lastContext && currentUsage) {
+					renderUsageWidget(lastContext, currentUsage);
+				}
+			},
+		});
+	}
 
 	pi.on("session_start", async (_event, ctx) => {
 		lastContext = ctx;

--- a/packages/sub-bar/src/settings-types.ts
+++ b/packages/sub-bar/src/settings-types.ts
@@ -267,6 +267,19 @@ export interface ProviderSettingsMap {
 export type { BehaviorSettings, CoreSettings } from "@marckrenn/pi-sub-shared";
 
 /**
+ * Keybinding settings.
+ * Values are key-combo strings accepted by pi's registerShortcut (e.g. "ctrl+alt+p").
+ * Use "none" to disable a shortcut.
+ * Changes take effect after pi restart.
+ */
+export interface KeybindingSettings {
+	/** Shortcut to cycle through providers */
+	cycleProvider: string;
+	/** Shortcut to toggle reset timer format */
+	toggleResetFormat: string;
+}
+
+/**
  * Display settings
  */
 export interface DisplaySettings {
@@ -378,6 +391,8 @@ export interface Settings extends Omit<CoreSettings, "providers"> {
 	displayUserTheme: DisplaySettings | null;
 	/** Pinned provider override for display */
 	pinnedProvider: ProviderName | null;
+	/** Keybinding settings (changes require pi restart) */
+	keybindings: KeybindingSettings;
 }
 
 /**
@@ -501,6 +516,11 @@ export function getDefaultSettings(): Settings {
 		displayThemes: [],
 		displayUserTheme: null,
 		pinnedProvider: null,
+
+		keybindings: {
+			cycleProvider: "ctrl+alt+p",
+			toggleResetFormat: "ctrl+alt+r",
+		},
 
 		behavior: {
 			refreshInterval: 60,

--- a/packages/sub-bar/src/settings.ts
+++ b/packages/sub-bar/src/settings.ts
@@ -40,6 +40,7 @@ function parseSettings(content: string): Settings {
 		displayThemes: loaded.displayThemes,
 		displayUserTheme: loaded.displayUserTheme,
 		pinnedProvider: loaded.pinnedProvider,
+		keybindings: loaded.keybindings,
 	} as Partial<Settings>);
 }
 
@@ -108,6 +109,7 @@ export function saveSettings(settings: Settings): boolean {
 				const themesChanged = JSON.stringify(settings.displayThemes) !== JSON.stringify(cachedSettings.displayThemes);
 				const userThemeChanged = JSON.stringify(settings.displayUserTheme) !== JSON.stringify(cachedSettings.displayUserTheme);
 				const pinnedChanged = settings.pinnedProvider !== cachedSettings.pinnedProvider;
+				const keybindingsChanged = JSON.stringify(settings.keybindings) !== JSON.stringify(cachedSettings.keybindings);
 
 				next = {
 					...diskSettings,
@@ -117,6 +119,7 @@ export function saveSettings(settings: Settings): boolean {
 					displayThemes: themesChanged ? settings.displayThemes : diskSettings.displayThemes,
 					displayUserTheme: userThemeChanged ? settings.displayUserTheme : diskSettings.displayUserTheme,
 					pinnedProvider: pinnedChanged ? settings.pinnedProvider : diskSettings.pinnedProvider,
+					keybindings: keybindingsChanged ? settings.keybindings : diskSettings.keybindings,
 				};
 			}
 		}
@@ -127,6 +130,7 @@ export function saveSettings(settings: Settings): boolean {
 			displayThemes: next.displayThemes,
 			displayUserTheme: next.displayUserTheme,
 			pinnedProvider: next.pinnedProvider,
+			keybindings: next.keybindings,
 		}, null, 2);
 		storage.writeFile(SETTINGS_PATH, content);
 		cachedSettings = next;
@@ -150,6 +154,7 @@ export function resetSettings(): Settings {
 		displayThemes: defaults.displayThemes,
 		displayUserTheme: defaults.displayUserTheme,
 		pinnedProvider: defaults.pinnedProvider,
+		keybindings: defaults.keybindings,
 		version: defaults.version,
 	};
 	saveSettings(next);

--- a/packages/sub-bar/src/settings/menu.ts
+++ b/packages/sub-bar/src/settings/menu.ts
@@ -12,6 +12,8 @@ export type TooltipSelectItem = SelectItem & { tooltip?: string };
 
 export function buildMainMenuItems(settings: Settings, pinnedProvider?: ProviderName | null): TooltipSelectItem[] {
 	const pinnedLabel = pinnedProvider ? PROVIDER_DISPLAY_NAMES[pinnedProvider] : "auto (current provider)";
+	const kb = settings.keybindings;
+	const kbDesc = `cycle: ${kb.cycleProvider}, reset: ${kb.toggleResetFormat}`;
 	return [
 		{
 			value: "display-theme",
@@ -36,6 +38,12 @@ export function buildMainMenuItems(settings: Settings, pinnedProvider?: Provider
 			label: "Provider Shown",
 			description: pinnedLabel,
 			tooltip: "Select which provider is shown in the widget.",
+		},
+		{
+			value: "keybindings",
+			label: "Keybindings",
+			description: kbDesc,
+			tooltip: "Configure keyboard shortcuts. Changes take effect after pi restart.",
 		},
 		{
 			value: "open-core-settings",

--- a/packages/sub-bar/src/settings/ui.ts
+++ b/packages/sub-bar/src/settings/ui.ts
@@ -60,6 +60,7 @@ type SettingsCategory =
 	| "providers"
 	| "pin-provider"
 	| ProviderCategory
+	| "keybindings"
 	| "display"
 	| "display-theme"
 	| "display-theme-save"
@@ -341,6 +342,7 @@ export async function showSettingsUI(
 					main: "sub-bar Settings",
 					providers: "Provider Settings",
 					"pin-provider": "Provider Shown",
+					keybindings: "Keybindings",
 					display: "Adv. Display Settings",
 					"display-theme": "Themes",
 					"display-theme-save": "Save Theme",
@@ -453,6 +455,72 @@ export async function showSettingsUI(
 					};
 					activeList = selectList;
 					container.addChild(selectList);
+				} else if (currentCategory === "keybindings") {
+					const parseKeybinding = (raw: string): string | null => {
+						const trimmed = raw.trim().toLowerCase();
+						if (!trimmed) {
+							ctx.ui.notify("Enter a key combo (e.g. ctrl+alt+p) or 'none' to disable", "warning");
+							return null;
+						}
+						if (trimmed === "none") return "none";
+						const parts = trimmed.split("+");
+						const modifiers = new Set(["ctrl", "shift", "alt"]);
+						const baseKeys = parts.filter((p) => !modifiers.has(p));
+						if (baseKeys.length !== 1) {
+							ctx.ui.notify("Invalid key combo. Use format like ctrl+alt+p or ctrl+s", "warning");
+							return null;
+						}
+						return trimmed;
+					};
+
+					const kbItems: SettingItem[] = [
+						{
+							id: "cycleProvider",
+							label: "Cycle Provider",
+							currentValue: settings.keybindings.cycleProvider,
+							description: "Shortcut to cycle through providers. Changes take effect after pi restart.",
+							submenu: buildInputSubmenu(
+								"Cycle Provider shortcut",
+								parseKeybinding,
+								undefined,
+								"Enter a key combo (e.g. ctrl+alt+p) or 'none' to disable.",
+							),
+						},
+						{
+							id: "toggleResetFormat",
+							label: "Toggle Reset Format",
+							currentValue: settings.keybindings.toggleResetFormat,
+							description: "Shortcut to toggle reset timer format. Changes take effect after pi restart.",
+							submenu: buildInputSubmenu(
+								"Toggle Reset Format shortcut",
+								parseKeybinding,
+								undefined,
+								"Enter a key combo (e.g. ctrl+alt+r) or 'none' to disable.",
+							),
+						},
+					];
+
+					const handleKbChange = (id: string, value: string) => {
+						if (id === "cycleProvider" || id === "toggleResetFormat") {
+							settings.keybindings = { ...settings.keybindings, [id]: value };
+							saveSettings(settings);
+							if (onSettingsChange) void onSettingsChange(settings);
+						}
+					};
+
+					const kbList = new SettingsList(
+						kbItems,
+						Math.min(kbItems.length + 3, 10),
+						getSettingsListTheme(),
+						handleKbChange,
+						() => {
+							currentCategory = "main";
+							rebuild();
+							tui.requestRender();
+						},
+					);
+					activeList = kbList;
+					container.addChild(kbList);
 				} else if (currentCategory === "providers") {
 					const items = buildProviderListItems(settings, coreSettings.providers);
 					const selectList = new SelectList(items, Math.min(items.length, 10), {
@@ -1238,6 +1306,7 @@ export async function showSettingsUI(
 				// Help text
 				const usesSettingsList =
 					Boolean(providerCategory) ||
+					currentCategory === "keybindings" ||
 					currentCategory === "display-layout" ||
 					currentCategory === "display-bar" ||
 					currentCategory === "display-provider" ||


### PR DESCRIPTION
# Configurable keybindings

## Summary

This PR makes `sub-bar`'s keyboard shortcuts configurable via settings.

## User-visible changes

* New setting: `sub-bar:settings → Keybindings → Cycle Provider`
  * Default: `ctrl+alt+p`
  * Set to `none` to disable
* New setting: `sub-bar:settings → Keybindings → Toggle Reset Format`
  * Default: `ctrl+alt+r`
  * Set to `none` to disable
* Keybinding changes take effect after pi restart.

## Implementation notes

* Added `KeybindingSettings` type with `cycleProvider` and `toggleResetFormat` fields to the `Settings` interface.
* Settings are loaded from disk at extension init time (before `registerShortcut` calls), changed from `getDefaultSettings()` to `loadSettings()`.
* Shortcuts with value `"none"` skip `registerShortcut` registration entirely.
* Keybindings are persisted alongside other sub-bar settings in `pi-sub-bar-settings.json`.
* Settings UI validates key combos (modifier+base key format) and accepts `"none"` to disable.

## Why

* `Ctrl+Alt+P` conflicted with a common shortcut in another extension (plan-mode)
