### PR TITLE
fix: support API key auth format for z.ai provider

### DIFF
--- a/packages/sub-core/src/providers/impl/zai.ts
+++ b/packages/sub-core/src/providers/impl/zai.ts
@@ -26,7 +26,7 @@ function loadZaiApiKey(deps: Dependencies): string | undefined {
 	try {
 		if (deps.fileExists(authPath)) {
 			const auth = JSON.parse(deps.readFile(authPath) ?? "{}");
-			return auth["z-ai"]?.access || auth["zai"]?.access;
+			return auth["z-ai"]?.access || auth["z-ai"]?.key || auth["zai"]?.access || auth["zai"]?.key;
 		}
 	} catch {
 		// Ignore parse errors


### PR DESCRIPTION
## Problem

Pi stores API keys in auth.json with format auth[provider].key while OAuth tokens use auth[provider].access. The z.ai provider was only checking for .access, causing it to miss valid API key credentials stored by pi.

## Root Cause

In packages/sub-core/src/providers/impl/zai.ts line 28:
return auth["z-ai"]?.access || auth["zai"]?.access;

This only looks for OAuth-style credentials (.access) but pi stores API keys as .key.

## Solution

Updated to check both formats:
return auth["z-ai"]?.access || auth["z-ai"]?.key || auth["zai"]?.access || auth["zai"]?.key;

## Testing

- Verified z.ai API returns valid usage data with the API key
- Tested with local fork - z.ai subscription metrics now display correctly
- Other providers (Anthropic, Codex) use OAuth so they correctly check .access