### PR TITLE
sub-bar: add status-line mode

### DIFF
--- a/packages/sub-bar/index.ts
+++ b/packages/sub-bar/index.ts
@@ -471,12 +471,13 @@ export default function createExtension(pi: ExtensionAPI) {
 		usage: UsageSnapshot | undefined,
 		contentWidth: number,
 		message?: string,
-		options?: { forceNoFill?: boolean }
+		options?: { forceNoFill?: boolean; forceLeftAlignment?: boolean }
 	): string[] {
 		const paddingLeft = settings.display.paddingLeft ?? 0;
 		const paddingRight = settings.display.paddingRight ?? 0;
 		const innerWidth = Math.max(1, contentWidth - paddingLeft - paddingRight);
-		const alignment = settings.display.alignment ?? "left";
+		const configuredAlignment = settings.display.alignment ?? "left";
+		const alignment = options?.forceLeftAlignment ? "left" : configuredAlignment;
 		const configuredHasFill = settings.display.barWidth === "fill" || settings.display.dividerBlanks === "fill";
 		const hasFill = options?.forceNoFill ? false : configuredHasFill;
 		const wantsSplit = options?.forceNoFill ? false : alignment === "split";
@@ -529,17 +530,65 @@ export default function createExtension(pi: ExtensionAPI) {
 		return lines;
 	}
 
+	function buildStatusEdgeDivider(theme: Theme): string {
+		const dividerChar = settings.display.dividerCharacter ?? "│";
+		if (dividerChar === "none") return "";
+		const dividerColor: ThemeColor = resolveDividerColor(settings.display.dividerColor);
+		const dividerGlyph = dividerChar === "blank" ? " " : dividerChar;
+		if (!dividerGlyph) return "";
+		const blanks = typeof settings.display.dividerBlanks === "number" ? settings.display.dividerBlanks : 1;
+		const spacing = " ".repeat(Math.max(0, blanks));
+		return `${spacing}${theme.fg(dividerColor, dividerGlyph)}${spacing}`;
+	}
+
 	function renderUsageWidget(ctx: ExtensionContext, usage: UsageSnapshot | undefined, message?: string): void {
 		if (!ctx.hasUI || !uiEnabled) {
 			return;
 		}
 
+		const placement = settings.display.widgetPlacement ?? "belowEditor";
 
+		if (placement === "status") {
+			ctx.ui.setWidget("usage", undefined);
+			if (!usage && !message) {
+				ctx.ui.setStatus("sub-bar", "");
+				return;
+			}
+			const theme = ctx.ui.theme;
+			const terminalWidth = process.stdout.columns || 80;
+			// In status-line placement we must not use fill-based layouts (they assume full terminal width).
+			// The Pi footer concatenates *all* extension statuses onto one line and then truncates,
+			// so we render at natural width here to avoid padding that would overflow when other
+			// status hooks are present.
+			const lines = formatUsageContent(ctx, theme, usage, terminalWidth, message, {
+				forceNoFill: true,
+				forceLeftAlignment: true,
+			});
+			if (lines.length === 0) {
+				ctx.ui.setStatus("sub-bar", "");
+				return;
+			}
+			let statusLine = lines.join(" ");
+			const edgeDivider = buildStatusEdgeDivider(theme);
+			if (edgeDivider) {
+				if (settings.display.statusLeadingDivider) {
+					statusLine = `${edgeDivider}${statusLine}`;
+				}
+				if (settings.display.statusTrailingDivider) {
+					statusLine = `${statusLine}${edgeDivider}`;
+				}
+			}
+			ctx.ui.setStatus("sub-bar", truncateToWidth(statusLine, terminalWidth, theme.fg("dim", "...")));
+			return;
+		}
+
+		ctx.ui.setStatus("sub-bar", "");
 		if (!usage && !message) {
 			ctx.ui.setWidget("usage", undefined);
 			return;
 		}
 
+		const widgetPlacement = placement === "aboveEditor" ? "aboveEditor" : "belowEditor";
 		const setWidgetWithPlacement = (ctx.ui as unknown as { setWidget: (...args: unknown[]) => void }).setWidget;
 		setWidgetWithPlacement(
 			"usage",
@@ -575,7 +624,7 @@ export default function createExtension(pi: ExtensionAPI) {
 				},
 				invalidate() {},
 			}),
-			{ placement: "belowEditor" },
+			{ placement: widgetPlacement },
 		);
 	}
 

--- a/packages/sub-bar/src/settings-types.ts
+++ b/packages/sub-bar/src/settings-types.ts
@@ -53,7 +53,7 @@ export type WidgetWrapping = OverflowMode;
 /**
  * Widget placement
  */
-export type WidgetPlacement = "belowEditor";
+export type WidgetPlacement = "aboveEditor" | "belowEditor" | "status";
 
 /**
  * Alignment for the widget
@@ -345,6 +345,10 @@ export interface DisplaySettings {
 	dividerBlanks: DividerBlanks;
 	/** Show divider between provider label and usage */
 	showProviderDivider: boolean;
+	/** Show leading divider in status-line placement */
+	statusLeadingDivider: boolean;
+	/** Show trailing divider in status-line placement */
+	statusTrailingDivider: boolean;
 	/** Connect divider glyphs to the bottom divider line */
 	dividerFooterJoin: boolean;
 	/** Show divider line above the bar */
@@ -503,6 +507,8 @@ export function getDefaultSettings(): Settings {
 			dividerColor: "dim",
 			dividerBlanks: 1,
 			showProviderDivider: true,
+			statusLeadingDivider: false,
+			statusTrailingDivider: false,
 			dividerFooterJoin: true,
 			showTopDivider: false,
 			showBottomDivider: true,

--- a/packages/sub-bar/src/settings/display.ts
+++ b/packages/sub-bar/src/settings/display.ts
@@ -22,6 +22,7 @@ import type {
 	StatusIconPack,
 	DividerColor,
 	UsageColorTargets,
+	WidgetPlacement,
 } from "../settings-types.js";
 import {
 	BASE_COLOR_OPTIONS,
@@ -31,8 +32,20 @@ import {
 } from "../settings-types.js";
 import { CUSTOM_OPTION } from "../ui/settings-list.js";
 
+function isStatusLinePlacement(settings: Settings): boolean {
+	return (settings.display.widgetPlacement ?? "belowEditor") === "status";
+}
+
 export function buildDisplayLayoutItems(settings: Settings): SettingItem[] {
+	const statusPlacement = isStatusLinePlacement(settings);
 	return [
+		{
+			id: "widgetPlacement",
+			label: "Widget Placement",
+			currentValue: settings.display.widgetPlacement ?? "belowEditor",
+			values: ["aboveEditor", "belowEditor", "status"] as WidgetPlacement[],
+			description: "Show as widget above/below editor (3 lines) or compact in footer status line (1 line).",
+		},
 		{
 			id: "showContextBar",
 			label: "Show Context Bar",
@@ -43,9 +56,13 @@ export function buildDisplayLayoutItems(settings: Settings): SettingItem[] {
 		{
 			id: "alignment",
 			label: "Alignment",
-			currentValue: settings.display.alignment,
-			values: ["left", "center", "right", "split"] as DisplayAlignment[],
-			description: "Align the usage line inside the widget.",
+			currentValue: statusPlacement ? "left" : settings.display.alignment,
+			values: statusPlacement
+				? (["left"] as DisplayAlignment[])
+				: (["left", "center", "right", "split"] as DisplayAlignment[]),
+			description: statusPlacement
+				? "Status-line placement always uses left alignment."
+				: "Align the usage line inside the widget.",
 		},
 		{
 			id: "overflow",
@@ -220,6 +237,10 @@ export function buildDisplayColorItems(settings: Settings): SettingItem[] {
 }
 
 export function buildDisplayBarItems(settings: Settings): SettingItem[] {
+	const statusPlacement = isStatusLinePlacement(settings);
+	const barWidthValues = statusPlacement
+		? (["1", "4", "6", "8", "10", "12", CUSTOM_OPTION] as string[])
+		: (["1", "4", "6", "8", "10", "12", "fill", CUSTOM_OPTION] as string[]);
 	const items: SettingItem[] = [
 		{
 			id: "barType",
@@ -251,8 +272,10 @@ export function buildDisplayBarItems(settings: Settings): SettingItem[] {
 			id: "barWidth",
 			label: "Bar Width",
 			currentValue: String(settings.display.barWidth),
-			values: ["1", "4", "6", "8", "10", "12", "fill", CUSTOM_OPTION],
-			description: "Set the bar width or fill available space.",
+			values: barWidthValues,
+			description: statusPlacement
+				? "Set the bar width (fill is unavailable in status-line placement)."
+				: "Set the bar width or fill available space.",
 		},
 		{
 			id: "containBar",
@@ -430,7 +453,8 @@ export function buildDisplayStatusItems(settings: Settings): SettingItem[] {
 }
 
 export function buildDisplayDividerItems(settings: Settings): SettingItem[] {
-	return [
+	const statusPlacement = isStatusLinePlacement(settings);
+	const commonItems: SettingItem[] = [
 		{
 			id: "dividerCharacter",
 			label: "Divider Character",
@@ -466,6 +490,30 @@ export function buildDisplayDividerItems(settings: Settings): SettingItem[] {
 			values: ["on", "off"],
 			description: "Show the divider after the provider label.",
 		},
+	];
+
+	if (statusPlacement) {
+		return [
+			...commonItems,
+			{
+				id: "statusLeadingDivider",
+				label: "Status Leading Divider",
+				currentValue: settings.display.statusLeadingDivider ? "on" : "off",
+				values: ["on", "off"],
+				description: "Add a divider before the status-line output.",
+			},
+			{
+				id: "statusTrailingDivider",
+				label: "Status Trailing Divider",
+				currentValue: settings.display.statusTrailingDivider ? "on" : "off",
+				values: ["on", "off"],
+				description: "Add a divider after the status-line output.",
+			},
+		];
+	}
+
+	return [
+		...commonItems,
 		{
 			id: "showTopDivider",
 			label: "Show Top Divider",
@@ -487,7 +535,6 @@ export function buildDisplayDividerItems(settings: Settings): SettingItem[] {
 			values: ["on", "off"],
 			description: "Draw reverse-T connectors for top/bottom dividers.",
 		},
-
 	];
 }
 
@@ -640,6 +687,9 @@ export function applyDisplayChange(settings: Settings, id: string, value: string
 		case "boldWindowTitle":
 			settings.display.boldWindowTitle = value === "on";
 			break;
+		case "widgetPlacement":
+			settings.display.widgetPlacement = value as WidgetPlacement;
+			break;
 		case "showContextBar":
 			settings.display.showContextBar = value === "on";
 			break;
@@ -676,6 +726,12 @@ export function applyDisplayChange(settings: Settings, id: string, value: string
 		}
 		case "showProviderDivider":
 			settings.display.showProviderDivider = value === "on";
+			break;
+		case "statusLeadingDivider":
+			settings.display.statusLeadingDivider = value === "on";
+			break;
+		case "statusTrailingDivider":
+			settings.display.statusTrailingDivider = value === "on";
 			break;
 		case "dividerFooterJoin":
 			settings.display.dividerFooterJoin = value === "on";

--- a/packages/sub-bar/src/settings/menu.ts
+++ b/packages/sub-bar/src/settings/menu.ts
@@ -120,8 +120,8 @@ export function buildDisplayMenuItems(): TooltipSelectItem[] {
 		{
 			value: "display-divider",
 			label: "Dividers",
-			description: "character, blanks, status divider, lines",
-			tooltip: "Change divider character, spacing, status separator, and divider lines.",
+			description: "character, blanks, status separators",
+			tooltip: "Change divider character, spacing, status separators, and widget divider lines.",
 		},
 		{
 			value: "display-color",

--- a/packages/sub-bar/src/settings/themes.ts
+++ b/packages/sub-bar/src/settings/themes.ts
@@ -182,11 +182,13 @@ export function resolveDisplayThemeTarget(
 				dividerColor: "dim",
 				dividerBlanks: 1,
 				showProviderDivider: true,
+				statusLeadingDivider: false,
+				statusTrailingDivider: false,
 				dividerFooterJoin: true,
 				showTopDivider: false,
 				showBottomDivider: false,
 				paddingLeft: 1,
-			paddingRight: 1,
+				paddingRight: 1,
 				widgetPlacement: "belowEditor",
 				errorThreshold: 25,
 				warningThreshold: 50,
@@ -252,12 +254,16 @@ export function buildRandomDisplay(base: DisplaySettings): DisplaySettings {
 	display.dividerColor = pickRandom(RANDOM_DIVIDER_COLORS);
 	display.dividerBlanks = pickRandom(RANDOM_DIVIDER_BLANKS);
 	display.showProviderDivider = randomBool();
+	display.statusLeadingDivider = randomBool();
+	display.statusTrailingDivider = randomBool();
 	display.dividerFooterJoin = randomBool();
 	display.showTopDivider = randomBool();
 	display.showBottomDivider = randomBool();
 
 	if (display.dividerCharacter === "none") {
 		display.showProviderDivider = false;
+		display.statusLeadingDivider = false;
+		display.statusTrailingDivider = false;
 		display.dividerFooterJoin = false;
 		display.showTopDivider = false;
 		display.showBottomDivider = false;

--- a/packages/sub-bar/src/settings/ui.ts
+++ b/packages/sub-bar/src/settings/ui.ts
@@ -184,7 +184,13 @@ export async function showSettingsUI(
 					ctx.ui.notify("Enter a value", "warning");
 					return null;
 				}
-				if (trimmed === "fill") return "fill";
+				if (trimmed === "fill") {
+					if ((settings.display.widgetPlacement ?? "belowEditor") === "status") {
+						ctx.ui.notify("fill is unavailable in status-line placement", "warning");
+						return null;
+					}
+					return "fill";
+				}
 				return parseInteger(trimmed, 0, 100);
 			};
 
@@ -1260,10 +1266,14 @@ export async function showSettingsUI(
 					attachCustomInputs(items, customHandlers);
 
 					handleChange = (id, value) => {
-						const previousStatusPack = settings.display.statusIconPack;
 						settings = applyDisplayChange(settings, id, value);
 						saveSettings(settings);
 						if (onSettingsChange) void onSettingsChange(settings);
+						if (currentCategory === "display-layout" && id === "widgetPlacement") {
+							rebuild();
+							tui.requestRender();
+							return;
+						}
 						if (currentCategory === "display-bar" && id === "barType") {
 							rebuild();
 							tui.requestRender();

--- a/packages/sub-bar/test/settings.test.ts
+++ b/packages/sub-bar/test/settings.test.ts
@@ -4,7 +4,12 @@ import type { Theme } from "@mariozechner/pi-coding-agent";
 import { visibleWidth } from "@mariozechner/pi-tui";
 import { formatUsageStatus, formatUsageWindowParts } from "../src/formatting.js";
 import { buildDisplayShareString, decodeDisplayShareString } from "../src/share.js";
-import { applyDisplayChange } from "../src/settings/display.js";
+import {
+	applyDisplayChange,
+	buildDisplayBarItems,
+	buildDisplayDividerItems,
+	buildDisplayLayoutItems,
+} from "../src/settings/display.js";
 import { buildDisplayThemeItems, saveDisplayTheme, upsertDisplayTheme } from "../src/settings/themes.js";
 import { getDefaultSettings, resolveBaseTextColor } from "../src/settings-types.js";
 import type { UsageSnapshot } from "../src/types.js";
@@ -206,6 +211,54 @@ test("applyDisplayChange accepts custom reset containment", () => {
 	const settings = getDefaultSettings();
 	applyDisplayChange(settings, "resetTimeContainment", "{}");
 	assert.equal(settings.display.resetTimeContainment, "{}");
+});
+
+test("layout items expose aboveEditor and clamp status alignment choices", () => {
+	const settings = getDefaultSettings();
+
+	let items = buildDisplayLayoutItems(settings);
+	const placementItem = items.find((item) => item.id === "widgetPlacement");
+	assert.deepEqual(placementItem?.values, ["aboveEditor", "belowEditor", "status"]);
+
+	settings.display.widgetPlacement = "status";
+	items = buildDisplayLayoutItems(settings);
+	const alignmentItem = items.find((item) => item.id === "alignment");
+	assert.deepEqual(alignmentItem?.values, ["left"]);
+	assert.equal(alignmentItem?.currentValue, "left");
+});
+
+test("status placement hides fill width option", () => {
+	const settings = getDefaultSettings();
+	settings.display.widgetPlacement = "status";
+
+	const items = buildDisplayBarItems(settings);
+	const barWidthItem = items.find((item) => item.id === "barWidth");
+	assert.ok(barWidthItem);
+	assert.ok(!(barWidthItem?.values ?? []).includes("fill"));
+});
+
+test("divider items switch between widget and status placement options", () => {
+	const settings = getDefaultSettings();
+
+	let items = buildDisplayDividerItems(settings);
+	assert.ok(items.some((item) => item.id === "showTopDivider"));
+	assert.ok(items.some((item) => item.id === "showBottomDivider"));
+	assert.ok(!items.some((item) => item.id === "statusLeadingDivider"));
+
+	settings.display.widgetPlacement = "status";
+	items = buildDisplayDividerItems(settings);
+	assert.ok(!items.some((item) => item.id === "showTopDivider"));
+	assert.ok(!items.some((item) => item.id === "showBottomDivider"));
+	assert.ok(items.some((item) => item.id === "statusLeadingDivider"));
+	assert.ok(items.some((item) => item.id === "statusTrailingDivider"));
+});
+
+test("applyDisplayChange toggles status edge dividers", () => {
+	const settings = getDefaultSettings();
+	applyDisplayChange(settings, "statusLeadingDivider", "on");
+	applyDisplayChange(settings, "statusTrailingDivider", "on");
+	assert.equal(settings.display.statusLeadingDivider, true);
+	assert.equal(settings.display.statusTrailingDivider, true);
 });
 
 test("decodeDisplayShareString rejects invalid payloads", () => {


### PR DESCRIPTION
Follows up on PR #10 . My apologies for the delay.

## Summary of Improvements
- add `widgetPlacement=status` to render usage in Pi footer status line
- add `widgetPlacement=aboveEditor` support in widget mode
- add status-line edge divider toggles (`statusLeadingDivider`, `statusTrailingDivider`)
- enforce status-mode layout constraints (left alignment, no fill-based layout)
- clear stale `sub-bar` status output when leaving status placement
- update display settings menus/types/defaults/theme handling for new placement/options
- add tests for placement options and status-specific divider controls

## Validation
- `npm --workspace packages/sub-bar test` (53 passing)
