### PR TITLE
feat: add sub-status for compact quota visibility

### DIFF
--- a/.changeset/bright-radios-develop.md
+++ b/.changeset/bright-radios-develop.md
@@ -1,0 +1,5 @@
+---
+"@marckrenn/pi-sub-status": minor
+---
+
+Add `@marckrenn/pi-sub-status`, a compact status-line client that renders `sub-core` quota updates via `ctx.ui.setStatus(...)`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
             { name: "@marckrenn/pi-sub-bar", changelog: "packages/sub-bar/CHANGELOG.md" },
             { name: "@marckrenn/pi-sub-core", changelog: "packages/sub-core/CHANGELOG.md" },
             { name: "@marckrenn/pi-sub-shared", changelog: "packages/sub-shared/CHANGELOG.md" },
+            { name: "@marckrenn/pi-sub-status", changelog: "packages/sub-status/CHANGELOG.md" },
           ];
 
           function extractSection(changelogPath) {

--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@ Monorepo for the `sub-*` extension ecosystem: a shared usage core (`sub-core`), 
 
 - **sub-core**: fetches usage + status, manages cache/locks, owns provider selection, and emits updates via `pi.events`.
 - **sub-bar**: UI widget that renders the current usage state above the editor.
+- **sub-status**: compact status-line client that renders the current usage state via `ctx.ui.setStatus(...)`.
 - **sub-shared**: shared types + event contract (published to npm as `@marckrenn/pi-sub-shared`).
 
-`sub-core` can power multiple `sub-*` extensions at once (some with UI, some headless).
+`sub-core` can power multiple `sub-*` extensions at once, including rich UI clients like `sub-bar` and compact/headless-friendly clients like `sub-status`.
 
 ## Packages
 
 | Package | Description |
 | --- | --- |
 | [`@marckrenn/pi-sub-core`](./packages/sub-core) | Shared fetch/cache core (pi extension). |
-| [`@marckrenn/pi-sub-bar`](./packages/sub-bar) | UI display client (pi extension). |
+| [`@marckrenn/pi-sub-bar`](./packages/sub-bar) | Rich widget display client (pi extension). |
+| [`@marckrenn/pi-sub-status`](./packages/sub-status) | Compact status-line display client (pi extension). |
 | [`@marckrenn/pi-sub-shared`](./packages/sub-shared) | Shared types + event contract (npm package). |
 
 ## Ideas / planned sub-* extensions
@@ -40,30 +42,35 @@ You can install the packages via `pi install`:
 ```bash
 pi install npm:@marckrenn/pi-sub-core
 pi install npm:@marckrenn/pi-sub-bar
+pi install npm:@marckrenn/pi-sub-status
 ```
+
+`sub-bar` remains the default rich UI path. `sub-status` is an explicit opt-in compact client and can be installed alongside `sub-bar` when you want both the widget and a status-line summary.
 
 ## Quick Start (manual install)
 
 ```bash
 git clone https://github.com/marckrenn/pi-sub.git
 
-# Enable extensions
-ln -s /path/to/pi-sub/packages/sub-core ~/.pi/agent/extensions/sub-core
-ln -s /path/to/pi-sub/packages/sub-bar  ~/.pi/agent/extensions/sub-bar
+# Enable the shared core plus one or both display clients
+ln -s /path/to/pi-sub/packages/sub-core   ~/.pi/agent/extensions/sub-core
+ln -s /path/to/pi-sub/packages/sub-bar    ~/.pi/agent/extensions/sub-bar
+ln -s /path/to/pi-sub/packages/sub-status ~/.pi/agent/extensions/sub-status
 ```
 
-Alternative (no symlink): add both to `~/.pi/agent/settings.json`:
+Alternative (no symlink): add the core plus whichever clients you want to `~/.pi/agent/settings.json`:
 
 ```json
 {
   "extensions": [
     "/path/to/pi-sub/packages/sub-core/index.ts",
-    "/path/to/pi-sub/packages/sub-bar/index.ts"
+    "/path/to/pi-sub/packages/sub-bar/index.ts",
+    "/path/to/pi-sub/packages/sub-status/index.ts"
   ]
 }
 ```
 
-> You only install `sub-core` + `sub-bar`. `sub-shared` is an npm dependency and is pulled automatically.
+> `sub-shared` is an npm dependency and is pulled automatically. `sub-bar` and `sub-status` are both optional clients on top of `sub-core`.
 
 ## Communication model (core ↔ clients)
 
@@ -93,7 +100,7 @@ Why: awaiting fetches inside `pi.on("session_start")` / `pi.on("model_select")` 
 - `sub-core:settings:patch` → `{ patch }` (persists core settings)
 - `sub-core:action` → `{ type: "refresh" | "cycleProvider", force? }`
 
-UI extensions like `sub-bar` listen for updates and render the current provider state.
+UI extensions like `sub-bar` and compact clients like `sub-status` listen for updates and render the current provider state in their own format.
 
 ## Settings & Cache
 
@@ -166,7 +173,7 @@ npm install
 Common commands:
 
 - `npm run check` — typecheck all workspaces
-- `npm run test` — run workspace tests (sub-bar + sub-core)
+- `npm run test` — run workspace tests (sub-bar + sub-core + sub-status)
 - `npm run lint` / `npm run lint:fix` — lint TypeScript
 - `npm run format` — format with Prettier
 - `npm run verify` — run check + test + lint
@@ -176,8 +183,10 @@ Watch mode:
 ```bash
 npm run check:watch -w @marckrenn/pi-sub-core
 npm run check:watch -w @marckrenn/pi-sub-bar
+npm run check:watch -w @marckrenn/pi-sub-status
 npm run check:watch -w @marckrenn/pi-sub-shared
 npm run test:watch -w @marckrenn/pi-sub-bar
+npm run test:watch -w @marckrenn/pi-sub-status
 ```
 
 Workspace-specific commands:
@@ -185,9 +194,11 @@ Workspace-specific commands:
 ```bash
 npm run check -w @marckrenn/pi-sub-core
 npm run check -w @marckrenn/pi-sub-bar
+npm run check -w @marckrenn/pi-sub-status
 npm run check -w @marckrenn/pi-sub-shared
 npm run test -w @marckrenn/pi-sub-core
 npm run test -w @marckrenn/pi-sub-bar
+npm run test -w @marckrenn/pi-sub-status
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1903,6 +1903,10 @@
       "resolved": "packages/sub-shared",
       "link": true
     },
+    "node_modules/@marckrenn/pi-sub-status": {
+      "resolved": "packages/sub-status",
+      "link": true
+    },
     "node_modules/@mariozechner/clipboard": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
@@ -6815,14 +6819,11 @@
     },
     "packages/sub-bar": {
       "name": "@marckrenn/pi-sub-bar",
-      "version": "1.2.0",
-      "bundleDependencies": [
-        "@marckrenn/pi-sub-core"
-      ],
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@marckrenn/pi-sub-core": "^1.2.0",
-        "@marckrenn/pi-sub-shared": "^1.2.0"
+        "@marckrenn/pi-sub-core": "^1.3.0",
+        "@marckrenn/pi-sub-shared": "^1.3.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6835,10 +6836,10 @@
     },
     "packages/sub-core": {
       "name": "@marckrenn/pi-sub-core",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@marckrenn/pi-sub-shared": "^1.2.0"
+        "@marckrenn/pi-sub-shared": "^1.3.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6851,9 +6852,26 @@
     },
     "packages/sub-shared": {
       "name": "@marckrenn/pi-sub-shared",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "devDependencies": {
         "typescript": "^5.8.0"
+      }
+    },
+    "packages/sub-status": {
+      "name": "@marckrenn/pi-sub-status",
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@marckrenn/pi-sub-core": "^1.3.0",
+        "@marckrenn/pi-sub-shared": "^1.3.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.8.0"
+      },
+      "peerDependencies": {
+        "@mariozechner/pi-coding-agent": "*"
       }
     }
   }

--- a/packages/sub-status/.gitignore
+++ b/packages/sub-status/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+settings.json
+cache.json
+cache.lock

--- a/packages/sub-status/.npmignore
+++ b/packages/sub-status/.npmignore
@@ -1,0 +1,15 @@
+# never ship packed artifacts
+*.tgz
+
+# local install artifacts
+node_modules
+package-lock.json
+
+# local dev files
+settings.json
+.DS_Store
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/sub-status/README.md
+++ b/packages/sub-status/README.md
@@ -1,0 +1,57 @@
+# sub-status
+
+Compact status-line client for [pi-coding-agent](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent).
+
+`sub-status` is a small passive companion to `sub-core`: it renders current quota usage via `ctx.ui.setStatus(...)`, without widget UI, commands, or settings UI in v1.
+
+On startup it follows the same bootstrap pattern as `sub-bar`, requests the current `sub-core` state, and then listens for `sub-core:ready` / `sub-core:update-current` to keep the compact line up to date. It stays deliberately quiet: no placeholder text when state is unavailable, and the status clears entirely when no usable usage snapshot exists.
+
+## Installation
+
+Install via the pi package manager:
+
+```bash
+pi install npm:@marckrenn/pi-sub-status
+```
+
+Use `-l` to install into project settings instead of global:
+
+```bash
+pi install -l npm:@marckrenn/pi-sub-status
+```
+
+`sub-status` follows the same package metadata/bootstrap pattern as `sub-bar`: it depends on `sub-core`, declares the same extra extension paths in package metadata, and probes/auto-loads `sub-core` at runtime for resilience.
+
+## Relationship to the other packages
+
+- `sub-core` is the shared source of truth for provider detection, fetching, cache/state, and events.
+- `sub-bar` is the rich widget UI and remains the default visual package.
+- `sub-status` is an optional compact client for status-line-friendly and RPC-friendly hosts.
+
+Installing `sub-status` alongside `sub-bar` is expected to be supported: `sub-bar` owns the rich widget, while `sub-status` owns a compact status line.
+
+## Current v1 scope
+
+- Shows windows only
+- Shows the first two windows only
+- Prefers reset descriptions when available, otherwise falls back to window labels
+- Shows percentages for each window
+- Appends compact stale / incident suffix text when relevant
+- Updates from `sub-core` startup/current-state events
+- Clears the status entirely when no usable current state exists
+
+## Not in v1
+
+- Commands
+- Settings UI
+- `setWidget`
+- `ctx.ui.custom(...)`
+- Provider/model labels in the compact line
+- Hybrid label + reset output in the compact line
+
+## Development
+
+```bash
+npm run check -w @marckrenn/pi-sub-status
+npm run test -w @marckrenn/pi-sub-status
+```

--- a/packages/sub-status/index.ts
+++ b/packages/sub-status/index.ts
@@ -1,0 +1,9 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { createStatusRuntime, type RuntimeDependencies } from "./src/runtime.js";
+
+/**
+ * Create the compact status-line client.
+ */
+export default function createExtension(pi: ExtensionAPI, dependencies?: RuntimeDependencies): void {
+	createStatusRuntime(pi, dependencies);
+}

--- a/packages/sub-status/package.json
+++ b/packages/sub-status/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@marckrenn/pi-sub-status",
+  "version": "1.3.0",
+  "description": "Compact status-line client for pi subscription usage",
+  "keywords": [
+    "pi-package"
+  ],
+  "type": "module",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts",
+      "node_modules/@marckrenn/pi-sub-core/index.ts",
+      "../pi-sub-core/index.ts"
+    ]
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "check:watch": "tsc --noEmit --watch",
+    "test": "tsx test/all.test.ts",
+    "test:watch": "tsx watch test/all.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@marckrenn/pi-sub-core": "^1.3.0",
+    "@marckrenn/pi-sub-shared": "^1.3.0"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  }
+}

--- a/packages/sub-status/src/format.ts
+++ b/packages/sub-status/src/format.ts
@@ -1,0 +1,63 @@
+import type { ProviderStatus, RateWindow, UsageSnapshot } from "@marckrenn/pi-sub-shared";
+
+function clampPercent(value: number): number {
+	return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function formatWindow(window: RateWindow): string {
+	const percent = `${clampPercent(window.usedPercent)}%`;
+	const label = window.resetDescription?.trim() || window.label.trim();
+	return label ? `${label} ${percent}` : percent;
+}
+
+function mapIncident(status?: ProviderStatus): string | undefined {
+	if (!status || status.indicator === "none") return undefined;
+	switch (status.indicator) {
+		case "minor":
+			return "degraded";
+		case "major":
+		case "critical":
+			return "outage";
+		case "maintenance":
+			return "maintenance";
+		case "unknown":
+		default:
+			return "unknown";
+	}
+}
+
+function isStale(usage: UsageSnapshot): boolean {
+	return Boolean(usage.error && usage.lastSuccessAt);
+}
+
+function isSyntheticStaleStatus(usage: UsageSnapshot): boolean {
+	// sub-core currently uses a minor status with an elapsed description for stale fallback data.
+	return isStale(usage) && usage.status?.indicator === "minor";
+}
+
+/**
+ * Format the current usage snapshot into a compact status-line string.
+ */
+export function formatCompactStatus(usage: UsageSnapshot | undefined): string | undefined {
+	if (!usage || usage.windows.length === 0) {
+		return undefined;
+	}
+
+	const parts = usage.windows.slice(0, 2).map(formatWindow);
+	if (parts.length === 0) {
+		return undefined;
+	}
+
+	if (isStale(usage)) {
+		parts.push("stale");
+	}
+
+	if (!isSyntheticStaleStatus(usage)) {
+		const incident = mapIncident(usage.status);
+		if (incident) {
+			parts.push(incident);
+		}
+	}
+
+	return parts.join(" · ");
+}

--- a/packages/sub-status/src/runtime.ts
+++ b/packages/sub-status/src/runtime.ts
@@ -1,0 +1,181 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { SubCoreState } from "@marckrenn/pi-sub-shared";
+import { formatCompactStatus } from "./format.js";
+
+const STATUS_KEY = "sub-status:usage";
+const DEFAULT_PROBE_TIMEOUT_MS = 200;
+const DEFAULT_REQUEST_TIMEOUT_MS = 1000;
+
+type SubCoreRequest = {
+	type?: "current";
+	includeSettings?: boolean;
+	reply: (payload: { state: SubCoreState }) => void;
+};
+
+/**
+ * Optional dependencies for testing and runtime probing.
+ */
+export type RuntimeDependencies = {
+	probeTimeoutMs?: number;
+	requestTimeoutMs?: number;
+	importModule?: (specifier: string) => Promise<unknown>;
+	logWarning?: (message: string, error: unknown) => void;
+};
+
+function resolveTimeout(value: number | undefined, fallback: number): number {
+	return value ?? fallback;
+}
+
+function getCreateCore(module: unknown): ((api: ExtensionAPI) => void | Promise<void>) | undefined {
+	const candidate = (module as { default?: unknown }).default;
+	return typeof candidate === "function"
+		? (candidate as (api: ExtensionAPI) => void | Promise<void>)
+		: undefined;
+}
+
+function requestSubCoreCurrent<T>(
+	pi: ExtensionAPI,
+	timeoutMs: number,
+	onReply: (payload: { state: SubCoreState }) => T,
+	onTimeout: T
+): Promise<T> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			resolve(onTimeout);
+		}, timeoutMs);
+		timer.unref?.();
+
+		const request: SubCoreRequest = {
+			type: "current",
+			reply: (payload) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				resolve(onReply(payload));
+			},
+		};
+
+		pi.events.emit("sub-core:request", request);
+	});
+}
+
+function probeSubCore(pi: ExtensionAPI, timeoutMs: number): Promise<boolean> {
+	return requestSubCoreCurrent(pi, timeoutMs, () => true, false);
+}
+
+function requestCoreState(pi: ExtensionAPI, timeoutMs: number): Promise<SubCoreState | undefined> {
+	return requestSubCoreCurrent(pi, timeoutMs, (payload) => payload.state, undefined);
+}
+
+async function loadSubCoreFactory(
+	importModule: (specifier: string) => Promise<unknown>,
+	logWarning: (message: string, error: unknown) => void
+): Promise<((api: ExtensionAPI) => void | Promise<void>) | undefined> {
+	const specifiers = [new URL("../node_modules/@marckrenn/pi-sub-core/index.ts", import.meta.url).toString(), "@marckrenn/pi-sub-core"];
+	let failure: unknown = new Error("sub-core module did not export a default extension factory");
+
+	for (const specifier of specifiers) {
+		try {
+			const module = await importModule(specifier);
+			const createCore = getCreateCore(module);
+			if (createCore) {
+				return createCore;
+			}
+			failure = new Error(`${specifier} did not export a default extension factory`);
+		} catch (error) {
+			failure = error;
+		}
+	}
+
+	logWarning("Failed to auto-load sub-core", failure);
+	return undefined;
+}
+
+/**
+ * Wire sub-status into the sub-core event flow for the current pi session.
+ */
+export function createStatusRuntime(pi: ExtensionAPI, dependencies: RuntimeDependencies = {}): void {
+	let lastContext: ExtensionContext | undefined;
+	let lastRenderedStatus: string | undefined;
+	let subCoreBootstrapAttempted = false;
+	let currentStateVersion = 0;
+
+	const probeTimeoutMs = resolveTimeout(dependencies.probeTimeoutMs, DEFAULT_PROBE_TIMEOUT_MS);
+	const requestTimeoutMs = resolveTimeout(dependencies.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS);
+	const importModule = dependencies.importModule ?? ((specifier: string) => import(specifier));
+	const logWarning = dependencies.logWarning ?? ((message: string, error: unknown) => console.warn(`${message}:`, error));
+
+	function renderStatus(ctx: ExtensionContext, state: SubCoreState | undefined): void {
+		const nextStatus = formatCompactStatus(state?.usage);
+		if (nextStatus === lastRenderedStatus) {
+			return;
+		}
+		ctx.ui.setStatus(STATUS_KEY, nextStatus);
+		lastRenderedStatus = nextStatus;
+	}
+
+	async function ensureSubCoreLoaded(): Promise<void> {
+		if (subCoreBootstrapAttempted) {
+			return;
+		}
+		subCoreBootstrapAttempted = true;
+
+		if (await probeSubCore(pi, probeTimeoutMs)) {
+			return;
+		}
+
+		const createCore = await loadSubCoreFactory(importModule, logWarning);
+		if (!createCore) {
+			return;
+		}
+		await createCore(pi);
+	}
+
+	function renderCurrentState(state: SubCoreState | undefined): void {
+		currentStateVersion += 1;
+		if (!lastContext) {
+			return;
+		}
+		renderStatus(lastContext, state);
+	}
+
+	pi.events.on("sub-core:ready", (payload) => {
+		const event = payload as { state?: SubCoreState };
+		renderCurrentState(event.state);
+	});
+
+	pi.events.on("sub-core:update-current", (payload) => {
+		const event = payload as { state?: SubCoreState };
+		renderCurrentState(event.state);
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		lastContext = ctx;
+		const requestStateVersion = currentStateVersion;
+
+		void (async () => {
+			await ensureSubCoreLoaded();
+			if (lastContext !== ctx) {
+				return;
+			}
+			const state = await requestCoreState(pi, requestTimeoutMs);
+			if (lastContext !== ctx || currentStateVersion !== requestStateVersion) {
+				return;
+			}
+			renderStatus(ctx, state);
+		})();
+	});
+
+	pi.on("session_shutdown", () => {
+		if (lastContext) {
+			renderStatus(lastContext, undefined);
+		}
+		lastContext = undefined;
+		lastRenderedStatus = undefined;
+		subCoreBootstrapAttempted = false;
+		currentStateVersion = 0;
+	});
+}

--- a/packages/sub-status/test/all.test.ts
+++ b/packages/sub-status/test/all.test.ts
@@ -1,0 +1,2 @@
+import "./formatting.test.js";
+import "./runtime.test.js";

--- a/packages/sub-status/test/formatting.test.ts
+++ b/packages/sub-status/test/formatting.test.ts
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { ProviderStatus, UsageSnapshot } from "@marckrenn/pi-sub-shared";
+import { formatCompactStatus } from "../src/format.js";
+
+function buildUsage(overrides?: Partial<UsageSnapshot>): UsageSnapshot {
+	return {
+		provider: "anthropic",
+		displayName: "Anthropic (Claude)",
+		windows: [
+			{ label: "5h", usedPercent: 3, resetDescription: "3h4m" },
+			{ label: "Week", usedPercent: 7, resetDescription: "6d11h" },
+			{ label: "Extra", usedPercent: 11, resetDescription: "Tomorrow" },
+		],
+		...overrides,
+	};
+}
+
+function withStatus(indicator: ProviderStatus["indicator"]): UsageSnapshot {
+	return buildUsage({ status: { indicator } });
+}
+
+test("formats the first two windows using reset descriptions when available", () => {
+	assert.equal(formatCompactStatus(buildUsage()), "3h4m 3% · 6d11h 7%");
+});
+
+test("falls back to the window label when reset description is missing", () => {
+	const usage = buildUsage({
+		windows: [
+			{ label: "5h", usedPercent: 3, resetDescription: "3h4m" },
+			{ label: "Week", usedPercent: 7 },
+		],
+	});
+
+	assert.equal(formatCompactStatus(usage), "3h4m 3% · Week 7%");
+});
+
+test("formats a single window without provider label noise", () => {
+	const usage = buildUsage({ windows: [{ label: "Month", usedPercent: 42 }] });
+
+	assert.equal(formatCompactStatus(usage), "Month 42%");
+});
+
+test("formats rounded percent after reset descriptions", () => {
+	const usage = buildUsage({ windows: [{ label: "Month", usedPercent: 42.6, resetDescription: "2d" }] });
+
+	assert.equal(formatCompactStatus(usage), "2d 43%");
+});
+
+test("appends stale suffix text for fallback data", () => {
+	const usage = buildUsage({
+		error: { code: "FETCH_FAILED", message: "Fetch failed" },
+		lastSuccessAt: Date.now() - 60_000,
+	});
+
+	assert.equal(formatCompactStatus(usage), "3h4m 3% · 6d11h 7% · stale");
+});
+
+test("maps minor incidents to degraded suffix text", () => {
+	assert.equal(formatCompactStatus(withStatus("minor")), "3h4m 3% · 6d11h 7% · degraded");
+});
+
+test("maps major incidents to outage suffix text", () => {
+	assert.equal(formatCompactStatus(withStatus("major")), "3h4m 3% · 6d11h 7% · outage");
+});
+
+test("maps critical incidents to outage suffix text", () => {
+	assert.equal(formatCompactStatus(withStatus("critical")), "3h4m 3% · 6d11h 7% · outage");
+});
+
+test("maps maintenance incidents to maintenance suffix text", () => {
+	assert.equal(formatCompactStatus(withStatus("maintenance")), "3h4m 3% · 6d11h 7% · maintenance");
+});
+
+test("maps unknown incidents to unknown suffix text", () => {
+	assert.equal(formatCompactStatus(withStatus("unknown")), "3h4m 3% · 6d11h 7% · unknown");
+});
+
+test("does not append noise for operational status", () => {
+	assert.equal(formatCompactStatus(withStatus("none")), "3h4m 3% · 6d11h 7%");
+});
+
+test("stale fallback suppresses synthetic incident text", () => {
+	const usage = buildUsage({
+		status: { indicator: "minor", description: "5m ago" },
+		error: { code: "FETCH_FAILED", message: "Fetch failed" },
+		lastSuccessAt: Date.now() - 60_000,
+	});
+
+	assert.equal(formatCompactStatus(usage), "3h4m 3% · 6d11h 7% · stale");
+});
+
+test("formats combined stale and real incident suffixes when both are present", () => {
+	const usage = buildUsage({
+		status: { indicator: "maintenance" },
+		error: { code: "HTTP_ERROR", message: "HTTP 500", httpStatus: 500 },
+		lastSuccessAt: Date.now() - 60_000,
+	});
+
+	assert.equal(formatCompactStatus(usage), "3h4m 3% · 6d11h 7% · stale · maintenance");
+});
+
+test("returns undefined for missing usage", () => {
+	assert.equal(formatCompactStatus(undefined), undefined);
+});
+
+test("returns undefined for usage with no windows", () => {
+	assert.equal(formatCompactStatus(buildUsage({ windows: [] })), undefined);
+});

--- a/packages/sub-status/test/runtime.test.ts
+++ b/packages/sub-status/test/runtime.test.ts
@@ -1,0 +1,321 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createEventBus, type ExtensionAPI, type ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { SubCoreState, UsageSnapshot } from "@marckrenn/pi-sub-shared";
+import { createStatusRuntime } from "../src/runtime.js";
+
+type StatusCall = {
+	key: string;
+	text: string | undefined;
+};
+
+type WarningCall = {
+	message: string;
+	error: unknown;
+};
+
+type CallLog<T> = {
+	calls: T[];
+	push: (value: T) => void;
+	waitForCount: (count: number, timeoutMs?: number) => Promise<void>;
+};
+
+type FakePi = ExtensionAPI & {
+	commands: string[];
+	emitEvent: (event: string, ctx: ExtensionContext) => Promise<void>;
+};
+
+function buildUsage(overrides?: Partial<UsageSnapshot>): UsageSnapshot {
+	return {
+		provider: "anthropic",
+		displayName: "Anthropic (Claude)",
+		windows: [
+			{ label: "5h", usedPercent: 3, resetDescription: "3h4m" },
+			{ label: "Week", usedPercent: 7, resetDescription: "6d11h" },
+		],
+		...overrides,
+	};
+}
+
+function createCallLog<T>(): CallLog<T> {
+	const calls: T[] = [];
+	const waiters = new Set<() => void>();
+
+	return {
+		calls,
+		push(value) {
+			calls.push(value);
+			for (const resolve of waiters) {
+				resolve();
+			}
+		},
+		async waitForCount(count: number, timeoutMs = 200) {
+			if (calls.length >= count) {
+				return;
+			}
+
+			await new Promise<void>((resolve, reject) => {
+				const timer = setTimeout(() => {
+					waiters.delete(checkCount);
+					reject(new Error(`condition not met within ${timeoutMs}ms`));
+				}, timeoutMs);
+
+				const checkCount = () => {
+					if (calls.length < count) {
+						return;
+					}
+					clearTimeout(timer);
+					waiters.delete(checkCount);
+					resolve();
+				};
+
+				waiters.add(checkCount);
+			});
+		},
+	};
+}
+
+function createContext(options?: { hasUI?: boolean }): { ctx: ExtensionContext; statusCalls: StatusCall[]; waitForStatusCalls: (count: number, timeoutMs?: number) => Promise<void> } {
+	const statusLog = createCallLog<StatusCall>();
+	const ctx = {
+		ui: {
+			select: async () => undefined,
+			confirm: async () => false,
+			input: async () => undefined,
+			notify: () => {},
+			setStatus: (key: string, text: string | undefined) => {
+				statusLog.push({ key, text });
+			},
+			setWorkingMessage: () => {},
+			setWidget: () => {},
+			setFooter: () => {},
+			setHeader: () => {},
+			setTitle: () => {},
+			custom: async () => undefined,
+			setEditorText: () => {},
+		},
+		hasUI: options?.hasUI ?? false,
+		cwd: "/tmp/project",
+		sessionManager: {} as ExtensionContext["sessionManager"],
+		modelRegistry: {} as ExtensionContext["modelRegistry"],
+		model: undefined,
+		isIdle: () => true,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+	} as ExtensionContext;
+
+	return { ctx, statusCalls: statusLog.calls, waitForStatusCalls: statusLog.waitForCount };
+}
+
+function createFakePi(): FakePi {
+	const handlers = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>();
+	const commands: string[] = [];
+
+	const pi = {
+		events: createEventBus(),
+		commands,
+		on(event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) {
+			const current = handlers.get(event) ?? [];
+			current.push(handler);
+			handlers.set(event, current);
+		},
+		async emitEvent(event: string, ctx: ExtensionContext) {
+			for (const handler of handlers.get(event) ?? []) {
+				await handler({ type: event }, ctx);
+			}
+		},
+		registerCommand(name: string) {
+			commands.push(name);
+		},
+		registerTool: () => {
+			throw new Error("registerTool should not be called by sub-status");
+		},
+		registerShortcut: () => {
+			throw new Error("registerShortcut should not be called by sub-status");
+		},
+		registerFlag: () => {},
+		getFlag: () => undefined,
+		registerMessageRenderer: () => {},
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		appendEntry: () => {},
+		setSessionName: () => {},
+		getSessionName: () => undefined,
+		setLabel: () => {},
+		exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		setActiveTools: () => {},
+		setModel: async () => true,
+		getThinkingLevel: () => "high",
+		setThinkingLevel: () => {},
+		registerProvider: () => {},
+	} as unknown as FakePi;
+
+	return pi;
+}
+
+function registerCurrentStateReply(pi: FakePi, state: SubCoreState): void {
+	pi.events.on("sub-core:request", (payload) => {
+		const request = payload as { reply: (payload: { state: SubCoreState }) => void };
+		request.reply({ state });
+	});
+}
+
+function createDeferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+} {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+test("requests current state on startup and renders compact status without UI gating", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls, waitForStatusCalls } = createContext({ hasUI: false });
+	registerCurrentStateReply(pi, { usage: buildUsage() });
+
+	createStatusRuntime(pi);
+	await pi.emitEvent("session_start", ctx);
+	await waitForStatusCalls(1);
+
+	assert.deepEqual(statusCalls, [{ key: "sub-status:usage", text: "3h4m 3% · 6d11h 7%" }]);
+	assert.deepEqual(pi.commands, []);
+});
+
+test("updates the status on sub-core:update-current and suppresses duplicate writes", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls, waitForStatusCalls } = createContext();
+	registerCurrentStateReply(pi, { usage: buildUsage() });
+
+	createStatusRuntime(pi);
+	await pi.emitEvent("session_start", ctx);
+	await waitForStatusCalls(1);
+
+	pi.events.emit("sub-core:update-current", { state: { usage: buildUsage({ windows: [{ label: "Month", usedPercent: 42 }] }) } });
+	await waitForStatusCalls(2);
+	pi.events.emit("sub-core:update-current", { state: { usage: buildUsage({ windows: [{ label: "Month", usedPercent: 42 }] }) } });
+
+	assert.deepEqual(statusCalls, [
+		{ key: "sub-status:usage", text: "3h4m 3% · 6d11h 7%" },
+		{ key: "sub-status:usage", text: "Month 42%" },
+	]);
+});
+
+test("clears the status when current state becomes unusable and on session shutdown", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls, waitForStatusCalls } = createContext();
+	registerCurrentStateReply(pi, { usage: buildUsage() });
+
+	createStatusRuntime(pi);
+	await pi.emitEvent("session_start", ctx);
+	await waitForStatusCalls(1);
+
+	pi.events.emit("sub-core:update-current", { state: { usage: buildUsage({ windows: [] }) } });
+	await waitForStatusCalls(2);
+	await pi.emitEvent("session_shutdown", ctx);
+
+	assert.deepEqual(statusCalls, [
+		{ key: "sub-status:usage", text: "3h4m 3% · 6d11h 7%" },
+		{ key: "sub-status:usage", text: undefined },
+	]);
+});
+
+test("keeps a newer sub-core ready update when the startup request replies later with stale state", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls, waitForStatusCalls } = createContext();
+	const startupRequest = createDeferred<{ reply: (payload: { state: SubCoreState }) => void }>();
+	let requestCount = 0;
+
+	pi.events.on("sub-core:request", (payload) => {
+		const request = payload as { reply: (payload: { state: SubCoreState }) => void };
+		requestCount += 1;
+		if (requestCount === 1) {
+			request.reply({ state: {} });
+			return;
+		}
+		startupRequest.resolve(request);
+	});
+
+	createStatusRuntime(pi, { probeTimeoutMs: 1, requestTimeoutMs: 50 });
+	await pi.emitEvent("session_start", ctx);
+	const delayedRequest = await startupRequest.promise;
+
+	pi.events.emit("sub-core:ready", { state: { usage: buildUsage() } });
+	await waitForStatusCalls(1);
+	assert.deepEqual(statusCalls, [{ key: "sub-status:usage", text: "3h4m 3% · 6d11h 7%" }]);
+
+	delayedRequest.reply({ state: {} });
+	await new Promise((resolve) => setImmediate(resolve));
+
+	assert.deepEqual(statusCalls, [{ key: "sub-status:usage", text: "3h4m 3% · 6d11h 7%" }]);
+});
+
+test("tries bundled sub-core first and falls back to package resolution when probing fails", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls, waitForStatusCalls } = createContext();
+	const imports: string[] = [];
+
+	const importModule = async (specifier: string): Promise<unknown> => {
+		imports.push(specifier);
+		if (specifier.includes("node_modules/@marckrenn/pi-sub-core/index.ts")) {
+			throw new Error("missing bundled core");
+		}
+		if (specifier === "@marckrenn/pi-sub-core") {
+			return {
+				default(api: ExtensionAPI) {
+					(api.events as FakePi["events"]).on("sub-core:request", (payload) => {
+						const request = payload as { reply: (payload: { state: SubCoreState }) => void };
+						request.reply({ state: { usage: buildUsage({ windows: [{ label: "Month", usedPercent: 42 }] }) } });
+					});
+				},
+			};
+		}
+		throw new Error(`unexpected import: ${specifier}`);
+	};
+
+	createStatusRuntime(pi, {
+		probeTimeoutMs: 1,
+		requestTimeoutMs: 1,
+		importModule,
+	});
+	await pi.emitEvent("session_start", ctx);
+	await waitForStatusCalls(1);
+
+	assert.ok(imports[0].includes("node_modules/@marckrenn/pi-sub-core/index.ts"));
+	assert.equal(imports[1], "@marckrenn/pi-sub-core");
+	assert.deepEqual(statusCalls, [{ key: "sub-status:usage", text: "Month 42%" }]);
+});
+
+test("warns once when sub-core cannot be auto-loaded from either runtime import path", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls } = createContext();
+	const warningLog = createCallLog<WarningCall>();
+	const importLog = createCallLog<string>();
+
+	const importModule = async (specifier: string): Promise<unknown> => {
+		importLog.push(specifier);
+		return {};
+	};
+
+	createStatusRuntime(pi, {
+		probeTimeoutMs: 1,
+		requestTimeoutMs: 1,
+		importModule,
+		logWarning: (message, error) => warningLog.push({ message, error }),
+	});
+	await pi.emitEvent("session_start", ctx);
+	await warningLog.waitForCount(1);
+	await importLog.waitForCount(2);
+
+	assert.equal(warningLog.calls[0].message, "Failed to auto-load sub-core");
+	assert.equal(importLog.calls[1], "@marckrenn/pi-sub-core");
+	assert.deepEqual(statusCalls, []);
+});

--- a/packages/sub-status/tsconfig.json
+++ b/packages/sub-status/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Give sub-core users a lightweight status-line client for environments where the full sub-bar widget is a poor fit, including RPC-driven hosts such as pi-coding-agent Emacs mode. sub-status keeps quota state visible without depending on rich TUI/widget support.

- render the first two usage windows in a compact reset-first format, with stale/incident suffixes when relevant
- keep status updates accurate across startup and later sub-core events
- document installation/release flow and align sub-status packaging with the existing sub-bar pattern