### PR TITLE
release-1.4.0: sub-bar status-line defaults + compact sub-status

### DIFF
--- a/.changeset/bright-radios-develop.md
+++ b/.changeset/bright-radios-develop.md
@@ -1,0 +1,5 @@
+---
+"@marckrenn/pi-sub-status": minor
+---
+
+Add `@marckrenn/pi-sub-status`, a compact status-line client that renders `sub-core` quota updates via `ctx.ui.setStatus(...)`.

--- a/.changeset/bright-radios-develop.md
+++ b/.changeset/bright-radios-develop.md
@@ -2,4 +2,6 @@
 "@marckrenn/pi-sub-status": minor
 ---
 
-Add `@marckrenn/pi-sub-status`, a compact status-line client that renders `sub-core` quota updates via `ctx.ui.setStatus(...)`.
+Add `@marckrenn/pi-sub-status`, a compact status-line client that renders `sub-core` usage updates via `ctx.ui.setStatus(...)`.
+
+Thanks [@dnouri](https://github.com/dnouri) for PR [#48](https://github.com/marckrenn/pi-sub/pull/48).

--- a/.changeset/empty-suns-juggle.md
+++ b/.changeset/empty-suns-juggle.md
@@ -3,3 +3,5 @@
 ---
 
 Set bundled default themes to use transparent widget background (`backgroundColor: none`) by default.
+
+Thanks [@marckrenn](https://github.com/marckrenn) for aligning bundled defaults in this release line.

--- a/.changeset/empty-suns-juggle.md
+++ b/.changeset/empty-suns-juggle.md
@@ -1,0 +1,5 @@
+---
+"@marckrenn/pi-sub-bar": patch
+---
+
+Set bundled default themes to use transparent widget background (`backgroundColor: none`) by default.

--- a/.changeset/odd-moose-float.md
+++ b/.changeset/odd-moose-float.md
@@ -1,0 +1,9 @@
+---
+"@marckrenn/pi-sub-bar": patch
+---
+
+Fix the status-line placement defaults and behavior:
+
+- Keep `widgetPlacement` defaulting to `belowEditor` for merged settings state.
+- In `widgetPlacement: "status"`, force left alignment and truncate-only overflow.
+- Status-line placement: hide status-only alignment/overflow controls and apply compact formatting; disable right padding in footer mode where trailing spaces are not safely preservable. Left padding remains applied.

--- a/.changeset/odd-moose-float.md
+++ b/.changeset/odd-moose-float.md
@@ -7,3 +7,5 @@ Fix the status-line placement defaults and behavior:
 - Keep `widgetPlacement` defaulting to `belowEditor` for merged settings state.
 - In `widgetPlacement: "status"`, force left alignment and truncate-only overflow.
 - Status-line placement: hide status-only alignment/overflow controls and apply compact formatting; disable right padding in footer mode where trailing spaces are not safely preservable. Left padding remains applied.
+
+Thanks [@marckrenn](https://github.com/marckrenn) for the follow-up integration in this branch and [@pasky](https://github.com/pasky) for the original status-line work in PR [#44](https://github.com/marckrenn/pi-sub/pull/44).

--- a/.changeset/quiet-ears-smell.md
+++ b/.changeset/quiet-ears-smell.md
@@ -3,3 +3,5 @@
 ---
 
 Add a new built-in **Default Footer** display theme preset, applying a status-line optimized footer layout directly from the theme picker.
+
+Thanks [@marckrenn](https://github.com/marckrenn) for PR [#49](https://github.com/marckrenn/pi-sub/pull/49).

--- a/.changeset/quiet-ears-smell.md
+++ b/.changeset/quiet-ears-smell.md
@@ -1,0 +1,5 @@
+---
+"@marckrenn/pi-sub-bar": patch
+---
+
+Add a new built-in **Default Footer** display theme preset, applying a status-line optimized footer layout directly from the theme picker.

--- a/.changeset/transparent-bg-option.md
+++ b/.changeset/transparent-bg-option.md
@@ -1,0 +1,6 @@
+---
+"@marckrenn/pi-sub-bar": patch
+---
+Add support for a transparent widget background so users can disable background coloring when it reduces readability in their terminal theme.
+
+This introduces an explicit `none` background choice in display settings and preserves that preference through settings updates, so the bar can render without forced background ANSI styling.

--- a/.changeset/transparent-bg-option.md
+++ b/.changeset/transparent-bg-option.md
@@ -4,3 +4,5 @@
 Add support for a transparent widget background so users can disable background coloring when it reduces readability in their terminal theme.
 
 This introduces an explicit `none` background choice in display settings and preserves that preference through settings updates, so the bar can render without forced background ANSI styling.
+
+Thanks [@airtonix](https://github.com/airtonix) for implementing this in PR [#47](https://github.com/marckrenn/pi-sub/pull/47).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
             { name: "@marckrenn/pi-sub-bar", changelog: "packages/sub-bar/CHANGELOG.md" },
             { name: "@marckrenn/pi-sub-core", changelog: "packages/sub-core/CHANGELOG.md" },
             { name: "@marckrenn/pi-sub-shared", changelog: "packages/sub-shared/CHANGELOG.md" },
+            { name: "@marckrenn/pi-sub-status", changelog: "packages/sub-status/CHANGELOG.md" },
           ];
 
           function extractSection(changelogPath) {

--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@ Monorepo for the `sub-*` extension ecosystem: a shared usage core (`sub-core`), 
 
 - **sub-core**: fetches usage + status, manages cache/locks, owns provider selection, and emits updates via `pi.events`.
 - **sub-bar**: UI widget that renders the current usage state above the editor.
+- **sub-status**: compact status-line client that renders the current usage state via `ctx.ui.setStatus(...)`.
 - **sub-shared**: shared types + event contract (published to npm as `@marckrenn/pi-sub-shared`).
 
-`sub-core` can power multiple `sub-*` extensions at once (some with UI, some headless).
+`sub-core` can power multiple `sub-*` extensions at once, including rich UI clients like `sub-bar` and compact/headless-friendly clients like `sub-status`.
 
 ## Packages
 
 | Package | Description |
 | --- | --- |
 | [`@marckrenn/pi-sub-core`](./packages/sub-core) | Shared fetch/cache core (pi extension). |
-| [`@marckrenn/pi-sub-bar`](./packages/sub-bar) | UI display client (pi extension). |
+| [`@marckrenn/pi-sub-bar`](./packages/sub-bar) | Rich widget display client (pi extension). |
+| [`@marckrenn/pi-sub-status`](./packages/sub-status) | Compact status-line display client (pi extension). |
 | [`@marckrenn/pi-sub-shared`](./packages/sub-shared) | Shared types + event contract (npm package). |
 
 ## Ideas / planned sub-* extensions
@@ -40,30 +42,35 @@ You can install the packages via `pi install`:
 ```bash
 pi install npm:@marckrenn/pi-sub-core
 pi install npm:@marckrenn/pi-sub-bar
+pi install npm:@marckrenn/pi-sub-status
 ```
+
+`sub-bar` remains the default rich UI path. `sub-status` is an explicit opt-in compact client and can be installed alongside `sub-bar` when you want both the widget and a status-line summary.
 
 ## Quick Start (manual install)
 
 ```bash
 git clone https://github.com/marckrenn/pi-sub.git
 
-# Enable extensions
-ln -s /path/to/pi-sub/packages/sub-core ~/.pi/agent/extensions/sub-core
-ln -s /path/to/pi-sub/packages/sub-bar  ~/.pi/agent/extensions/sub-bar
+# Enable the shared core plus one or both display clients
+ln -s /path/to/pi-sub/packages/sub-core   ~/.pi/agent/extensions/sub-core
+ln -s /path/to/pi-sub/packages/sub-bar    ~/.pi/agent/extensions/sub-bar
+ln -s /path/to/pi-sub/packages/sub-status ~/.pi/agent/extensions/sub-status
 ```
 
-Alternative (no symlink): add both to `~/.pi/agent/settings.json`:
+Alternative (no symlink): add the core plus whichever clients you want to `~/.pi/agent/settings.json`:
 
 ```json
 {
   "extensions": [
     "/path/to/pi-sub/packages/sub-core/index.ts",
-    "/path/to/pi-sub/packages/sub-bar/index.ts"
+    "/path/to/pi-sub/packages/sub-bar/index.ts",
+    "/path/to/pi-sub/packages/sub-status/index.ts"
   ]
 }
 ```
 
-> You only install `sub-core` + `sub-bar`. `sub-shared` is an npm dependency and is pulled automatically.
+> `sub-shared` is an npm dependency and is pulled automatically. `sub-bar` and `sub-status` are both optional clients on top of `sub-core`.
 
 ## Communication model (core ↔ clients)
 
@@ -93,7 +100,7 @@ Why: awaiting fetches inside `pi.on("session_start")` / `pi.on("model_select")` 
 - `sub-core:settings:patch` → `{ patch }` (persists core settings)
 - `sub-core:action` → `{ type: "refresh" | "cycleProvider", force? }`
 
-UI extensions like `sub-bar` listen for updates and render the current provider state.
+UI extensions like `sub-bar` and compact clients like `sub-status` listen for updates and render the current provider state in their own format.
 
 ## Settings & Cache
 
@@ -166,7 +173,7 @@ npm install
 Common commands:
 
 - `npm run check` — typecheck all workspaces
-- `npm run test` — run workspace tests (sub-bar + sub-core)
+- `npm run test` — run workspace tests (sub-bar + sub-core + sub-status)
 - `npm run lint` / `npm run lint:fix` — lint TypeScript
 - `npm run format` — format with Prettier
 - `npm run verify` — run check + test + lint
@@ -176,8 +183,10 @@ Watch mode:
 ```bash
 npm run check:watch -w @marckrenn/pi-sub-core
 npm run check:watch -w @marckrenn/pi-sub-bar
+npm run check:watch -w @marckrenn/pi-sub-status
 npm run check:watch -w @marckrenn/pi-sub-shared
 npm run test:watch -w @marckrenn/pi-sub-bar
+npm run test:watch -w @marckrenn/pi-sub-status
 ```
 
 Workspace-specific commands:
@@ -185,9 +194,11 @@ Workspace-specific commands:
 ```bash
 npm run check -w @marckrenn/pi-sub-core
 npm run check -w @marckrenn/pi-sub-bar
+npm run check -w @marckrenn/pi-sub-status
 npm run check -w @marckrenn/pi-sub-shared
 npm run test -w @marckrenn/pi-sub-core
 npm run test -w @marckrenn/pi-sub-bar
+npm run test -w @marckrenn/pi-sub-status
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1903,6 +1903,10 @@
       "resolved": "packages/sub-shared",
       "link": true
     },
+    "node_modules/@marckrenn/pi-sub-status": {
+      "resolved": "packages/sub-status",
+      "link": true
+    },
     "node_modules/@mariozechner/clipboard": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
@@ -6815,14 +6819,11 @@
     },
     "packages/sub-bar": {
       "name": "@marckrenn/pi-sub-bar",
-      "version": "1.2.0",
-      "bundleDependencies": [
-        "@marckrenn/pi-sub-core"
-      ],
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@marckrenn/pi-sub-core": "^1.2.0",
-        "@marckrenn/pi-sub-shared": "^1.2.0"
+        "@marckrenn/pi-sub-core": "^1.3.0",
+        "@marckrenn/pi-sub-shared": "^1.3.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6835,10 +6836,10 @@
     },
     "packages/sub-core": {
       "name": "@marckrenn/pi-sub-core",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@marckrenn/pi-sub-shared": "^1.2.0"
+        "@marckrenn/pi-sub-shared": "^1.3.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6851,9 +6852,26 @@
     },
     "packages/sub-shared": {
       "name": "@marckrenn/pi-sub-shared",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "devDependencies": {
         "typescript": "^5.8.0"
+      }
+    },
+    "packages/sub-status": {
+      "name": "@marckrenn/pi-sub-status",
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "@marckrenn/pi-sub-core": "^1.3.0",
+        "@marckrenn/pi-sub-shared": "^1.3.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.8.0"
+      },
+      "peerDependencies": {
+        "@mariozechner/pi-coding-agent": "*"
       }
     }
   }

--- a/packages/sub-bar/index.ts
+++ b/packages/sub-bar/index.ts
@@ -471,12 +471,13 @@ export default function createExtension(pi: ExtensionAPI) {
 		usage: UsageSnapshot | undefined,
 		contentWidth: number,
 		message?: string,
-		options?: { forceNoFill?: boolean }
+		options?: { forceNoFill?: boolean; forceLeftAlignment?: boolean }
 	): string[] {
 		const paddingLeft = settings.display.paddingLeft ?? 0;
 		const paddingRight = settings.display.paddingRight ?? 0;
 		const innerWidth = Math.max(1, contentWidth - paddingLeft - paddingRight);
-		const alignment = settings.display.alignment ?? "left";
+		const configuredAlignment = settings.display.alignment ?? "left";
+		const alignment = options?.forceLeftAlignment ? "left" : configuredAlignment;
 		const configuredHasFill = settings.display.barWidth === "fill" || settings.display.dividerBlanks === "fill";
 		const hasFill = options?.forceNoFill ? false : configuredHasFill;
 		const wantsSplit = options?.forceNoFill ? false : alignment === "split";
@@ -529,17 +530,65 @@ export default function createExtension(pi: ExtensionAPI) {
 		return lines;
 	}
 
+	function buildStatusEdgeDivider(theme: Theme): string {
+		const dividerChar = settings.display.dividerCharacter ?? "│";
+		if (dividerChar === "none") return "";
+		const dividerColor: ThemeColor = resolveDividerColor(settings.display.dividerColor);
+		const dividerGlyph = dividerChar === "blank" ? " " : dividerChar;
+		if (!dividerGlyph) return "";
+		const blanks = typeof settings.display.dividerBlanks === "number" ? settings.display.dividerBlanks : 1;
+		const spacing = " ".repeat(Math.max(0, blanks));
+		return `${spacing}${theme.fg(dividerColor, dividerGlyph)}${spacing}`;
+	}
+
 	function renderUsageWidget(ctx: ExtensionContext, usage: UsageSnapshot | undefined, message?: string): void {
 		if (!ctx.hasUI || !uiEnabled) {
 			return;
 		}
 
+		const placement = settings.display.widgetPlacement ?? "belowEditor";
 
+		if (placement === "status") {
+			ctx.ui.setWidget("usage", undefined);
+			if (!usage && !message) {
+				ctx.ui.setStatus("sub-bar", "");
+				return;
+			}
+			const theme = ctx.ui.theme;
+			const terminalWidth = process.stdout.columns || 80;
+			// In status-line placement we must not use fill-based layouts (they assume full terminal width).
+			// The Pi footer concatenates *all* extension statuses onto one line and then truncates,
+			// so we render at natural width here to avoid padding that would overflow when other
+			// status hooks are present.
+			const lines = formatUsageContent(ctx, theme, usage, terminalWidth, message, {
+				forceNoFill: true,
+				forceLeftAlignment: true,
+			});
+			if (lines.length === 0) {
+				ctx.ui.setStatus("sub-bar", "");
+				return;
+			}
+			let statusLine = lines.join(" ");
+			const edgeDivider = buildStatusEdgeDivider(theme);
+			if (edgeDivider) {
+				if (settings.display.statusLeadingDivider) {
+					statusLine = `${edgeDivider}${statusLine}`;
+				}
+				if (settings.display.statusTrailingDivider) {
+					statusLine = `${statusLine}${edgeDivider}`;
+				}
+			}
+			ctx.ui.setStatus("sub-bar", truncateToWidth(statusLine, terminalWidth, theme.fg("dim", "...")));
+			return;
+		}
+
+		ctx.ui.setStatus("sub-bar", "");
 		if (!usage && !message) {
 			ctx.ui.setWidget("usage", undefined);
 			return;
 		}
 
+		const widgetPlacement = placement === "aboveEditor" ? "aboveEditor" : "belowEditor";
 		const setWidgetWithPlacement = (ctx.ui as unknown as { setWidget: (...args: unknown[]) => void }).setWidget;
 		setWidgetWithPlacement(
 			"usage",
@@ -575,7 +624,7 @@ export default function createExtension(pi: ExtensionAPI) {
 				},
 				invalidate() {},
 			}),
-			{ placement: "belowEditor" },
+			{ placement: widgetPlacement },
 		);
 	}
 

--- a/packages/sub-bar/index.ts
+++ b/packages/sub-bar/index.ts
@@ -10,8 +10,8 @@ import * as fs from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ProviderName, ProviderUsageEntry, SubCoreAllState, SubCoreState, UsageSnapshot } from "./src/types.js";
-import { type Settings, type BaseTextColor } from "./src/settings-types.js";
-import { isBackgroundColor, resolveBaseTextColor, resolveDividerColor } from "./src/settings-types.js";
+import { type Settings, type BaseTextColor, type WidgetBackgroundColor } from "./src/settings-types.js";
+import { isBackgroundColor, resolveBackgroundColor, resolveBaseTextColor, resolveDividerColor } from "./src/settings-types.js";
 import { buildDividerLine } from "./src/dividers.js";
 import type { CoreSettings } from "@marckrenn/pi-sub-shared";
 import type { KeyId } from "@mariozechner/pi-tui";
@@ -40,7 +40,8 @@ type SubCoreAction = {
 	force?: boolean;
 };
 
-function applyBackground(lines: string[], theme: Theme, color: BaseTextColor, width: number): string[] {
+function applyBackground(lines: string[], theme: Theme, color: WidgetBackgroundColor, width: number): string[] {
+	if (color === "none") return lines;
 	const bgAnsi = isBackgroundColor(color)
 		? theme.getBgAnsi(color as Parameters<Theme["getBgAnsi"]>[0])
 		: theme.getFgAnsi(resolveDividerColor(color)).replace(/\x1b\[38;/g, "\x1b[48;").replace(/\x1b\[39m/g, "\x1b[49m");
@@ -570,7 +571,7 @@ export default function createExtension(pi: ExtensionAPI) {
 						lines = [...lines, footerLine];
 					}
 
-					const backgroundColor = resolveBaseTextColor(settings.display.backgroundColor);
+					const backgroundColor = resolveBackgroundColor(settings.display.backgroundColor);
 					return applyBackground(lines, theme, backgroundColor, safeWidth);
 				},
 				invalidate() {},

--- a/packages/sub-bar/index.ts
+++ b/packages/sub-bar/index.ts
@@ -471,13 +471,17 @@ export default function createExtension(pi: ExtensionAPI) {
 		usage: UsageSnapshot | undefined,
 		contentWidth: number,
 		message?: string,
-		options?: { forceNoFill?: boolean; forceLeftAlignment?: boolean }
+		options?: { forceNoFill?: boolean; forceLeftAlignment?: boolean; forceOverflow?: "truncate" | "wrap"; useStatusSafePadding?: boolean }
 	): string[] {
 		const paddingLeft = settings.display.paddingLeft ?? 0;
-		const paddingRight = settings.display.paddingRight ?? 0;
-		const innerWidth = Math.max(1, contentWidth - paddingLeft - paddingRight);
+		const configuredPaddingRight = settings.display.paddingRight ?? 0;
+		const useStatusSafePadding = options?.useStatusSafePadding ?? false;
+		const resolvedPaddingRight = useStatusSafePadding ? 0 : configuredPaddingRight;
+		const innerWidth = Math.max(1, contentWidth - paddingLeft - resolvedPaddingRight);
 		const configuredAlignment = settings.display.alignment ?? "left";
 		const alignment = options?.forceLeftAlignment ? "left" : configuredAlignment;
+		const configuredOverflow = settings.display.overflow ?? "truncate";
+		const overflow = options?.forceOverflow ?? configuredOverflow;
 		const configuredHasFill = settings.display.barWidth === "fill" || settings.display.dividerBlanks === "fill";
 		const hasFill = options?.forceNoFill ? false : configuredHasFill;
 		const wantsSplit = options?.forceNoFill ? false : alignment === "split";
@@ -514,16 +518,35 @@ export default function createExtension(pi: ExtensionAPI) {
 		let lines: string[] = [];
 		if (!formatted) {
 			lines = [];
-		} else if (settings.display.overflow === "wrap") {
+		} else if (overflow === "wrap") {
 			lines = wrapTextWithAnsi(formatted, innerWidth).map(alignLine);
 		} else {
 			const trimmed = alignLine(truncateToWidth(formatted, innerWidth, theme.fg("dim", "...")));
 			lines = [trimmed];
 		}
 
-		if (paddingLeft > 0 || paddingRight > 0) {
-			const leftPad = " ".repeat(paddingLeft);
-			const rightPad = " ".repeat(paddingRight);
+		const effectivePaddingLeft = paddingLeft;
+		const effectivePaddingRight = useStatusSafePadding ? 0 : configuredPaddingRight;
+		if (effectivePaddingLeft > 0 || effectivePaddingRight > 0) {
+			const buildStatusSafePadding = (count: number) => {
+				const zeroWidth = "\u200B";
+				if (count <= 0) return "";
+				let out = "";
+				for (let i = 0; i < count; i++) {
+					out += " ";
+					out += zeroWidth;
+				}
+				if (count > 0) {
+					out += zeroWidth;
+				}
+				return out;
+			};
+			const leftPad = useStatusSafePadding
+				? buildStatusSafePadding(effectivePaddingLeft)
+				: " ".repeat(effectivePaddingLeft);
+			const rightPad = useStatusSafePadding
+				? ""
+				: " ".repeat(effectivePaddingRight);
 			lines = lines.map((line) => `${leftPad}${line}${rightPad}`);
 		}
 
@@ -563,6 +586,8 @@ export default function createExtension(pi: ExtensionAPI) {
 			const lines = formatUsageContent(ctx, theme, usage, terminalWidth, message, {
 				forceNoFill: true,
 				forceLeftAlignment: true,
+				forceOverflow: "truncate",
+				useStatusSafePadding: true,
 			});
 			if (lines.length === 0) {
 				ctx.ui.setStatus("sub-bar", "");

--- a/packages/sub-bar/src/settings-types.ts
+++ b/packages/sub-bar/src/settings-types.ts
@@ -53,7 +53,7 @@ export type WidgetWrapping = OverflowMode;
 /**
  * Widget placement
  */
-export type WidgetPlacement = "belowEditor";
+export type WidgetPlacement = "aboveEditor" | "belowEditor" | "status";
 
 /**
  * Alignment for the widget
@@ -345,6 +345,10 @@ export interface DisplaySettings {
 	dividerBlanks: DividerBlanks;
 	/** Show divider between provider label and usage */
 	showProviderDivider: boolean;
+	/** Show leading divider in status-line placement */
+	statusLeadingDivider: boolean;
+	/** Show trailing divider in status-line placement */
+	statusTrailingDivider: boolean;
 	/** Connect divider glyphs to the bottom divider line */
 	dividerFooterJoin: boolean;
 	/** Show divider line above the bar */
@@ -503,6 +507,8 @@ export function getDefaultSettings(): Settings {
 			dividerColor: "dim",
 			dividerBlanks: 1,
 			showProviderDivider: true,
+			statusLeadingDivider: false,
+			statusTrailingDivider: false,
 			dividerFooterJoin: true,
 			showTopDivider: false,
 			showBottomDivider: true,

--- a/packages/sub-bar/src/settings-types.ts
+++ b/packages/sub-bar/src/settings-types.ts
@@ -581,9 +581,27 @@ export function mergeSettings(loaded: Partial<Settings>): Settings {
 	return deepMerge(getDefaultSettings(), migrated);
 }
 
+const WIDGET_PLACEMENTS = ["aboveEditor", "belowEditor", "status"] as const;
+
+function coerceWidgetPlacement(raw?: unknown): WidgetPlacement | undefined {
+	if (typeof raw !== "string") return undefined;
+	if ((WIDGET_PLACEMENTS as readonly string[]).includes(raw)) {
+		return raw as WidgetPlacement;
+	}
+	return undefined;
+}
+
 function migrateDisplaySettings(display?: Partial<DisplaySettings> | null): void {
 	if (!display) return;
 	const displayAny = display as Partial<DisplaySettings> & { widgetWrapping?: OverflowMode; paddingX?: number };
+	const normalizedPlacement = coerceWidgetPlacement(displayAny.widgetPlacement);
+	if (displayAny.widgetPlacement !== undefined) {
+		displayAny.widgetPlacement = normalizedPlacement ?? "belowEditor";
+	}
+	if (displayAny.widgetPlacement === "status") {
+		displayAny.alignment = "left";
+		displayAny.overflow = "truncate";
+	}
 	if (displayAny.widgetWrapping !== undefined && displayAny.overflow === undefined) {
 		displayAny.overflow = displayAny.widgetWrapping;
 	}

--- a/packages/sub-bar/src/settings-types.ts
+++ b/packages/sub-bar/src/settings-types.ts
@@ -135,6 +135,13 @@ export const BASE_COLOR_OPTIONS = [...DIVIDER_COLOR_OPTIONS, ...BACKGROUND_COLOR
  */
 export type BaseTextColor = (typeof BASE_COLOR_OPTIONS)[number];
 
+/**
+ * Background options for the widget line.
+ */
+export const WIDGET_BACKGROUND_OPTIONS = ["none", ...BASE_COLOR_OPTIONS] as const;
+
+export type WidgetBackgroundColor = (typeof WIDGET_BACKGROUND_OPTIONS)[number];
+
 export function normalizeDividerColor(value?: string): DividerColor {
 	if (!value) return "borderMuted";
 	if (value === "accent" || value === "primary") return "primary";
@@ -177,8 +184,21 @@ export function normalizeBaseTextColor(value?: string): BaseTextColor {
 	return "dim";
 }
 
+export function normalizeBackgroundColor(value?: string): WidgetBackgroundColor {
+	if (!value || value === "none" || value === "transparent") return "none";
+	if (value === "accent" || value === "primary") return "primary";
+	if ((BASE_COLOR_OPTIONS as readonly string[]).includes(value)) {
+		return value as BaseTextColor;
+	}
+	return "none";
+}
+
 export function resolveBaseTextColor(value?: string): BaseTextColor {
 	return normalizeBaseTextColor(value);
+}
+
+export function resolveBackgroundColor(value?: string): WidgetBackgroundColor {
+	return normalizeBackgroundColor(value);
 }
 
 /**
@@ -330,7 +350,7 @@ export interface DisplaySettings {
 	/** Base text color for widget labels */
 	baseTextColor: BaseTextColor;
 	/** Background color for the widget line */
-	backgroundColor: BaseTextColor;
+	backgroundColor: WidgetBackgroundColor;
 	/** Show window titles (5h, Week, etc.) */
 	showWindowTitle: boolean;
 	/** Bold window titles (5h, Week, etc.) */

--- a/packages/sub-bar/src/settings-types.ts
+++ b/packages/sub-bar/src/settings-types.ts
@@ -519,7 +519,7 @@ export function getDefaultSettings(): Settings {
 			providerLabelColon: false,
 			providerLabelBold: true,
 			baseTextColor: "muted",
-			backgroundColor: "text",
+			backgroundColor: "none",
 			showWindowTitle: true,
 			boldWindowTitle: true,
 			showUsageLabels: true,

--- a/packages/sub-bar/src/settings/display.ts
+++ b/packages/sub-bar/src/settings/display.ts
@@ -22,6 +22,7 @@ import type {
 	StatusIconPack,
 	DividerColor,
 	UsageColorTargets,
+	WidgetPlacement,
 } from "../settings-types.js";
 import {
 	BASE_COLOR_OPTIONS,
@@ -31,8 +32,20 @@ import {
 } from "../settings-types.js";
 import { CUSTOM_OPTION } from "../ui/settings-list.js";
 
+function isStatusLinePlacement(settings: Settings): boolean {
+	return (settings.display.widgetPlacement ?? "belowEditor") === "status";
+}
+
 export function buildDisplayLayoutItems(settings: Settings): SettingItem[] {
+	const statusPlacement = isStatusLinePlacement(settings);
 	return [
+		{
+			id: "widgetPlacement",
+			label: "Widget Placement",
+			currentValue: settings.display.widgetPlacement ?? "belowEditor",
+			values: ["aboveEditor", "belowEditor", "status"] as WidgetPlacement[],
+			description: "Show as widget above/below editor (3 lines) or compact in footer status line (1 line).",
+		},
 		{
 			id: "showContextBar",
 			label: "Show Context Bar",
@@ -43,9 +56,13 @@ export function buildDisplayLayoutItems(settings: Settings): SettingItem[] {
 		{
 			id: "alignment",
 			label: "Alignment",
-			currentValue: settings.display.alignment,
-			values: ["left", "center", "right", "split"] as DisplayAlignment[],
-			description: "Align the usage line inside the widget.",
+			currentValue: statusPlacement ? "left" : settings.display.alignment,
+			values: statusPlacement
+				? (["left"] as DisplayAlignment[])
+				: (["left", "center", "right", "split"] as DisplayAlignment[]),
+			description: statusPlacement
+				? "Status-line placement always uses left alignment."
+				: "Align the usage line inside the widget.",
 		},
 		{
 			id: "overflow",
@@ -220,6 +237,10 @@ export function buildDisplayColorItems(settings: Settings): SettingItem[] {
 }
 
 export function buildDisplayBarItems(settings: Settings): SettingItem[] {
+	const statusPlacement = isStatusLinePlacement(settings);
+	const barWidthValues = statusPlacement
+		? (["1", "4", "6", "8", "10", "12", CUSTOM_OPTION] as string[])
+		: (["1", "4", "6", "8", "10", "12", "fill", CUSTOM_OPTION] as string[]);
 	const items: SettingItem[] = [
 		{
 			id: "barType",
@@ -251,8 +272,10 @@ export function buildDisplayBarItems(settings: Settings): SettingItem[] {
 			id: "barWidth",
 			label: "Bar Width",
 			currentValue: String(settings.display.barWidth),
-			values: ["1", "4", "6", "8", "10", "12", "fill", CUSTOM_OPTION],
-			description: "Set the bar width or fill available space.",
+			values: barWidthValues,
+			description: statusPlacement
+				? "Set the bar width (fill is unavailable in status-line placement)."
+				: "Set the bar width or fill available space.",
 		},
 		{
 			id: "containBar",
@@ -430,7 +453,8 @@ export function buildDisplayStatusItems(settings: Settings): SettingItem[] {
 }
 
 export function buildDisplayDividerItems(settings: Settings): SettingItem[] {
-	return [
+	const statusPlacement = isStatusLinePlacement(settings);
+	const commonItems: SettingItem[] = [
 		{
 			id: "dividerCharacter",
 			label: "Divider Character",
@@ -466,6 +490,30 @@ export function buildDisplayDividerItems(settings: Settings): SettingItem[] {
 			values: ["on", "off"],
 			description: "Show the divider after the provider label.",
 		},
+	];
+
+	if (statusPlacement) {
+		return [
+			...commonItems,
+			{
+				id: "statusLeadingDivider",
+				label: "Status Leading Divider",
+				currentValue: settings.display.statusLeadingDivider ? "on" : "off",
+				values: ["on", "off"],
+				description: "Add a divider before the status-line output.",
+			},
+			{
+				id: "statusTrailingDivider",
+				label: "Status Trailing Divider",
+				currentValue: settings.display.statusTrailingDivider ? "on" : "off",
+				values: ["on", "off"],
+				description: "Add a divider after the status-line output.",
+			},
+		];
+	}
+
+	return [
+		...commonItems,
 		{
 			id: "showTopDivider",
 			label: "Show Top Divider",
@@ -487,7 +535,6 @@ export function buildDisplayDividerItems(settings: Settings): SettingItem[] {
 			values: ["on", "off"],
 			description: "Draw reverse-T connectors for top/bottom dividers.",
 		},
-
 	];
 }
 
@@ -640,6 +687,9 @@ export function applyDisplayChange(settings: Settings, id: string, value: string
 		case "boldWindowTitle":
 			settings.display.boldWindowTitle = value === "on";
 			break;
+		case "widgetPlacement":
+			settings.display.widgetPlacement = value as WidgetPlacement;
+			break;
 		case "showContextBar":
 			settings.display.showContextBar = value === "on";
 			break;
@@ -676,6 +726,12 @@ export function applyDisplayChange(settings: Settings, id: string, value: string
 		}
 		case "showProviderDivider":
 			settings.display.showProviderDivider = value === "on";
+			break;
+		case "statusLeadingDivider":
+			settings.display.statusLeadingDivider = value === "on";
+			break;
+		case "statusTrailingDivider":
+			settings.display.statusTrailingDivider = value === "on";
 			break;
 		case "dividerFooterJoin":
 			settings.display.dividerFooterJoin = value === "on";

--- a/packages/sub-bar/src/settings/display.ts
+++ b/packages/sub-bar/src/settings/display.ts
@@ -38,7 +38,7 @@ function isStatusLinePlacement(settings: Settings): boolean {
 
 export function buildDisplayLayoutItems(settings: Settings): SettingItem[] {
 	const statusPlacement = isStatusLinePlacement(settings);
-	return [
+	const items: SettingItem[] = [
 		{
 			id: "widgetPlacement",
 			label: "Widget Placement",
@@ -53,39 +53,48 @@ export function buildDisplayLayoutItems(settings: Settings): SettingItem[] {
 			values: ["on", "off"],
 			description: "Show context window usage as leftmost progress bar.",
 		},
-		{
-			id: "alignment",
-			label: "Alignment",
-			currentValue: statusPlacement ? "left" : settings.display.alignment,
-			values: statusPlacement
-				? (["left"] as DisplayAlignment[])
-				: (["left", "center", "right", "split"] as DisplayAlignment[]),
-			description: statusPlacement
-				? "Status-line placement always uses left alignment."
-				: "Align the usage line inside the widget.",
-		},
-		{
-			id: "overflow",
-			label: "Overflow",
-			currentValue: settings.display.overflow,
-			values: ["truncate", "wrap"] as WidgetWrapping[],
-			description: "Wrap the usage line or truncate with ellipsis (requires bar width ≠ fill and alignment ≠ split).",
-		},
-		{
-			id: "paddingLeft",
-			label: "Padding Left",
-			currentValue: String(settings.display.paddingLeft ?? 0),
-			values: ["0", "1", "2", "3", "4", CUSTOM_OPTION],
-			description: "Add left padding inside the widget.",
-		},
-		{
+	];
+
+	if (!statusPlacement) {
+		items.push(
+			{
+				id: "alignment",
+				label: "Alignment",
+				currentValue: settings.display.alignment,
+				values: ["left", "center", "right", "split"] as DisplayAlignment[],
+				description: "Align the usage line inside the widget.",
+			},
+			{
+				id: "overflow",
+				label: "Overflow",
+				currentValue: settings.display.overflow,
+				values: ["truncate", "wrap"] as WidgetWrapping[],
+				description: "Wrap the usage line or truncate with ellipsis (requires bar width ≠ fill and alignment ≠ split).",
+			},
+		);
+	}
+
+	items.push({
+		id: "paddingLeft",
+		label: "Padding Left",
+		currentValue: String(settings.display.paddingLeft ?? 0),
+		values: ["0", "1", "2", "3", "4", CUSTOM_OPTION],
+		description: statusPlacement
+			? "Add left padding inside the compact status line."
+			: "Add left padding inside the widget.",
+	});
+
+	if (!statusPlacement) {
+		items.push({
 			id: "paddingRight",
 			label: "Padding Right",
 			currentValue: String(settings.display.paddingRight ?? 0),
 			values: ["0", "1", "2", "3", "4", CUSTOM_OPTION],
 			description: "Add right padding inside the widget.",
-		},
-	];
+		});
+	}
+
+	return items;
 }
 
 export function buildDisplayResetItems(settings: Settings): SettingItem[] {

--- a/packages/sub-bar/src/settings/display.ts
+++ b/packages/sub-bar/src/settings/display.ts
@@ -16,6 +16,7 @@ import type {
 	DividerBlanks,
 	ProviderLabel,
 	BaseTextColor,
+	WidgetBackgroundColor,
 	ResetTimeFormat,
 	ResetTimerContainment,
 	StatusIndicatorMode,
@@ -25,8 +26,10 @@ import type {
 } from "../settings-types.js";
 import {
 	BASE_COLOR_OPTIONS,
+	WIDGET_BACKGROUND_OPTIONS,
 	DIVIDER_COLOR_OPTIONS,
 	normalizeBaseTextColor,
+	normalizeBackgroundColor,
 	normalizeDividerColor,
 } from "../settings-types.js";
 import { CUSTOM_OPTION } from "../ui/settings-list.js";
@@ -174,8 +177,8 @@ export function buildDisplayColorItems(settings: Settings): SettingItem[] {
 		{
 			id: "backgroundColor",
 			label: "Background Color",
-			currentValue: normalizeBaseTextColor(settings.display.backgroundColor),
-			values: [...BASE_COLOR_OPTIONS] as BaseTextColor[],
+			currentValue: normalizeBackgroundColor(settings.display.backgroundColor),
+			values: [...WIDGET_BACKGROUND_OPTIONS] as WidgetBackgroundColor[],
 			description: "Background color for the widget line.",
 		},
 		{
@@ -629,7 +632,7 @@ export function applyDisplayChange(settings: Settings, id: string, value: string
 			settings.display.baseTextColor = normalizeBaseTextColor(value);
 			break;
 		case "backgroundColor":
-			settings.display.backgroundColor = normalizeBaseTextColor(value);
+			settings.display.backgroundColor = normalizeBackgroundColor(value);
 			break;
 		case "showUsageLabels":
 			settings.display.showUsageLabels = value === "on";

--- a/packages/sub-bar/src/settings/menu.ts
+++ b/packages/sub-bar/src/settings/menu.ts
@@ -120,8 +120,8 @@ export function buildDisplayMenuItems(): TooltipSelectItem[] {
 		{
 			value: "display-divider",
 			label: "Dividers",
-			description: "character, blanks, status divider, lines",
-			tooltip: "Change divider character, spacing, status separator, and divider lines.",
+			description: "character, blanks, status separators",
+			tooltip: "Change divider character, spacing, status separators, and widget divider lines.",
 		},
 		{
 			value: "display-color",

--- a/packages/sub-bar/src/settings/themes.ts
+++ b/packages/sub-bar/src/settings/themes.ts
@@ -116,6 +116,12 @@ export function buildDisplayThemeItems(
 		description: "compact display",
 		tooltip: "Apply the default minimal theme.",
 	});
+	items.push({
+		value: "default-footer",
+		label: "Default Footer",
+		description: "status-line optimized default footer style",
+		tooltip: "Apply a compact footer-style layout.",
+	});
 	for (const theme of settings.displayThemes) {
 		const description = theme.source === "imported" ? "manually imported theme" : "manually saved theme";
 		items.push({
@@ -140,6 +146,23 @@ export function resolveDisplayThemeTarget(
 	}
 	if (value === "default") {
 		return { name: "Default", display: { ...defaults.display }, deletable: false };
+	}
+	if (value === "default-footer") {
+		return {
+			name: "Default Footer",
+			display: {
+				...defaults.display,
+				alignment: "left",
+				barWidth: 4,
+				showUsageLabels: false,
+				statusIndicatorMode: "icon+text",
+				statusProviderDivider: true,
+				showProviderName: false,
+				statusLeadingDivider: true,
+				widgetPlacement: "status",
+			},
+			deletable: false,
+		};
 	}
 	if (value === "minimal") {
 		return {

--- a/packages/sub-bar/src/settings/themes.ts
+++ b/packages/sub-bar/src/settings/themes.ts
@@ -182,11 +182,13 @@ export function resolveDisplayThemeTarget(
 				dividerColor: "dim",
 				dividerBlanks: 1,
 				showProviderDivider: true,
+				statusLeadingDivider: false,
+				statusTrailingDivider: false,
 				dividerFooterJoin: true,
 				showTopDivider: false,
 				showBottomDivider: false,
 				paddingLeft: 1,
-			paddingRight: 1,
+				paddingRight: 1,
 				widgetPlacement: "belowEditor",
 				errorThreshold: 25,
 				warningThreshold: 50,
@@ -252,12 +254,16 @@ export function buildRandomDisplay(base: DisplaySettings): DisplaySettings {
 	display.dividerColor = pickRandom(RANDOM_DIVIDER_COLORS);
 	display.dividerBlanks = pickRandom(RANDOM_DIVIDER_BLANKS);
 	display.showProviderDivider = randomBool();
+	display.statusLeadingDivider = randomBool();
+	display.statusTrailingDivider = randomBool();
 	display.dividerFooterJoin = randomBool();
 	display.showTopDivider = randomBool();
 	display.showBottomDivider = randomBool();
 
 	if (display.dividerCharacter === "none") {
 		display.showProviderDivider = false;
+		display.statusLeadingDivider = false;
+		display.statusTrailingDivider = false;
 		display.dividerFooterJoin = false;
 		display.showTopDivider = false;
 		display.showBottomDivider = false;

--- a/packages/sub-bar/src/settings/themes.ts
+++ b/packages/sub-bar/src/settings/themes.ts
@@ -197,7 +197,7 @@ export function resolveDisplayThemeTarget(
 				providerLabelColon: false,
 				providerLabelBold: true,
 				baseTextColor: "muted",
-				backgroundColor: "text",
+				backgroundColor: "none",
 				showWindowTitle: false,
 				boldWindowTitle: true,
 				showUsageLabels: false,

--- a/packages/sub-bar/src/settings/ui.ts
+++ b/packages/sub-bar/src/settings/ui.ts
@@ -184,7 +184,13 @@ export async function showSettingsUI(
 					ctx.ui.notify("Enter a value", "warning");
 					return null;
 				}
-				if (trimmed === "fill") return "fill";
+				if (trimmed === "fill") {
+					if ((settings.display.widgetPlacement ?? "belowEditor") === "status") {
+						ctx.ui.notify("fill is unavailable in status-line placement", "warning");
+						return null;
+					}
+					return "fill";
+				}
 				return parseInteger(trimmed, 0, 100);
 			};
 
@@ -1260,10 +1266,14 @@ export async function showSettingsUI(
 					attachCustomInputs(items, customHandlers);
 
 					handleChange = (id, value) => {
-						const previousStatusPack = settings.display.statusIconPack;
 						settings = applyDisplayChange(settings, id, value);
 						saveSettings(settings);
 						if (onSettingsChange) void onSettingsChange(settings);
+						if (currentCategory === "display-layout" && id === "widgetPlacement") {
+							rebuild();
+							tui.requestRender();
+							return;
+						}
 						if (currentCategory === "display-bar" && id === "barType") {
 							rebuild();
 							tui.requestRender();

--- a/packages/sub-bar/test/settings.test.ts
+++ b/packages/sub-bar/test/settings.test.ts
@@ -10,8 +10,8 @@ import {
 	buildDisplayDividerItems,
 	buildDisplayLayoutItems,
 } from "../src/settings/display.js";
-import { buildDisplayThemeItems, saveDisplayTheme, upsertDisplayTheme } from "../src/settings/themes.js";
-import { getDefaultSettings, resolveBaseTextColor } from "../src/settings-types.js";
+import { buildDisplayThemeItems, resolveDisplayThemeTarget, saveDisplayTheme, upsertDisplayTheme } from "../src/settings/themes.js";
+import { getDefaultSettings, mergeSettings, resolveBaseTextColor } from "../src/settings-types.js";
 import type { UsageSnapshot } from "../src/types.js";
 
 const theme = {
@@ -109,6 +109,14 @@ test("share string preserves custom values and tolerates unknown colors", () => 
 	assert.equal(decoded?.display.providerLabel, "Team");
 	assert.equal(decoded?.display.barCharacter, "★");
 	assert.equal(resolveBaseTextColor(decoded?.display.baseTextColor), "dim");
+});
+
+
+
+test("theme list includes Default Footer preset", () => {
+	const items = buildDisplayThemeItems(getDefaultSettings());
+	const footerThemeItem = items.find((item) => item.value === "default-footer");
+	assert.equal(footerThemeItem?.label, "Default Footer");
 });
 
 test("theme source labels imported vs saved", () => {
@@ -213,7 +221,7 @@ test("applyDisplayChange accepts custom reset containment", () => {
 	assert.equal(settings.display.resetTimeContainment, "{}");
 });
 
-test("layout items expose aboveEditor and clamp status alignment choices", () => {
+test("layout items expose aboveEditor and hide status-only layout controls", () => {
 	const settings = getDefaultSettings();
 
 	let items = buildDisplayLayoutItems(settings);
@@ -222,9 +230,10 @@ test("layout items expose aboveEditor and clamp status alignment choices", () =>
 
 	settings.display.widgetPlacement = "status";
 	items = buildDisplayLayoutItems(settings);
-	const alignmentItem = items.find((item) => item.id === "alignment");
-	assert.deepEqual(alignmentItem?.values, ["left"]);
-	assert.equal(alignmentItem?.currentValue, "left");
+	assert.ok(!items.some((item) => item.id === "alignment"));
+	assert.ok(!items.some((item) => item.id === "overflow"));
+	assert.ok(items.some((item) => item.id === "paddingLeft"));
+	assert.ok(!items.some((item) => item.id === "paddingRight"));
 });
 
 test("status placement hides fill width option", () => {
@@ -259,6 +268,47 @@ test("applyDisplayChange toggles status edge dividers", () => {
 	applyDisplayChange(settings, "statusTrailingDivider", "on");
 	assert.equal(settings.display.statusLeadingDivider, true);
 	assert.equal(settings.display.statusTrailingDivider, true);
+});
+
+
+
+
+
+test("Default Footer preset applies footer defaults", () => {
+	const defaults = getDefaultSettings();
+	const target = resolveDisplayThemeTarget("default-footer", defaults, defaults, null);
+	assert.ok(target);
+	assert.equal(target?.name, "Default Footer");
+	assert.equal(target?.display.widgetPlacement, "status");
+	assert.equal(target?.display.statusIndicatorMode, "icon+text");
+	assert.equal(target?.display.barWidth, 4);
+	assert.equal(target?.deletable, false);
+});
+test("default widget placement stays belowEditor", () => {
+	const settings = getDefaultSettings();
+	assert.equal(settings.display.widgetPlacement, "belowEditor");
+});
+
+test("status placement normalizes alignment and overflow to line-mode defaults", () => {
+	const settings = mergeSettings({
+		display: {
+			widgetPlacement: "status",
+			alignment: "center",
+			overflow: "wrap",
+		} as any,
+	} as any);
+	assert.equal(settings.display.widgetPlacement, "status");
+	assert.equal(settings.display.alignment, "left");
+	assert.equal(settings.display.overflow, "truncate");
+});
+
+test("invalid widget placement falls back to belowEditor", () => {
+	const settings = mergeSettings({
+		display: {
+			widgetPlacement: "invalid",
+		} as any,
+	} as any);
+	assert.equal(settings.display.widgetPlacement, "belowEditor");
 });
 
 test("decodeDisplayShareString rejects invalid payloads", () => {

--- a/packages/sub-bar/test/settings.test.ts
+++ b/packages/sub-bar/test/settings.test.ts
@@ -4,7 +4,7 @@ import type { Theme } from "@mariozechner/pi-coding-agent";
 import { visibleWidth } from "@mariozechner/pi-tui";
 import { formatUsageStatus, formatUsageWindowParts } from "../src/formatting.js";
 import { buildDisplayShareString, decodeDisplayShareString } from "../src/share.js";
-import { applyDisplayChange } from "../src/settings/display.js";
+import { applyDisplayChange, buildDisplayColorItems } from "../src/settings/display.js";
 import { buildDisplayThemeItems, saveDisplayTheme, upsertDisplayTheme } from "../src/settings/themes.js";
 import { getDefaultSettings, resolveBaseTextColor } from "../src/settings-types.js";
 import type { UsageSnapshot } from "../src/types.js";
@@ -168,6 +168,20 @@ test("applyDisplayChange supports fill and numeric values", () => {
 	assert.equal(settings.display.dividerBlanks, "fill");
 	applyDisplayChange(settings, "dividerBlanks", "3");
 	assert.equal(settings.display.dividerBlanks, 3);
+});
+
+test("background color accepts none", () => {
+	const settings = getDefaultSettings();
+	applyDisplayChange(settings, "backgroundColor", "none");
+	assert.equal(settings.display.backgroundColor, "none");
+});
+
+test("display color items include none for background", () => {
+	const settings = getDefaultSettings();
+	const items = buildDisplayColorItems(settings);
+	const backgroundItem = items.find((item) => item.id === "backgroundColor");
+	assert.ok(backgroundItem);
+	assert.ok(backgroundItem.values?.includes("none"));
 });
 
 test("status icon pack parsing handles preview labels", () => {

--- a/packages/sub-bar/test/settings.test.ts
+++ b/packages/sub-bar/test/settings.test.ts
@@ -4,7 +4,12 @@ import type { Theme } from "@mariozechner/pi-coding-agent";
 import { visibleWidth } from "@mariozechner/pi-tui";
 import { formatUsageStatus, formatUsageWindowParts } from "../src/formatting.js";
 import { buildDisplayShareString, decodeDisplayShareString } from "../src/share.js";
-import { applyDisplayChange } from "../src/settings/display.js";
+import {
+	applyDisplayChange,
+	buildDisplayBarItems,
+	buildDisplayDividerItems,
+	buildDisplayLayoutItems,
+} from "../src/settings/display.js";
 import { buildDisplayThemeItems, saveDisplayTheme, upsertDisplayTheme } from "../src/settings/themes.js";
 import { getDefaultSettings, resolveBaseTextColor } from "../src/settings-types.js";
 import type { UsageSnapshot } from "../src/types.js";
@@ -206,6 +211,54 @@ test("applyDisplayChange accepts custom reset containment", () => {
 	const settings = getDefaultSettings();
 	applyDisplayChange(settings, "resetTimeContainment", "{}");
 	assert.equal(settings.display.resetTimeContainment, "{}");
+});
+
+test("layout items expose aboveEditor and clamp status alignment choices", () => {
+	const settings = getDefaultSettings();
+
+	let items = buildDisplayLayoutItems(settings);
+	const placementItem = items.find((item) => item.id === "widgetPlacement");
+	assert.deepEqual(placementItem?.values, ["aboveEditor", "belowEditor", "status"]);
+
+	settings.display.widgetPlacement = "status";
+	items = buildDisplayLayoutItems(settings);
+	const alignmentItem = items.find((item) => item.id === "alignment");
+	assert.deepEqual(alignmentItem?.values, ["left"]);
+	assert.equal(alignmentItem?.currentValue, "left");
+});
+
+test("status placement hides fill width option", () => {
+	const settings = getDefaultSettings();
+	settings.display.widgetPlacement = "status";
+
+	const items = buildDisplayBarItems(settings);
+	const barWidthItem = items.find((item) => item.id === "barWidth");
+	assert.ok(barWidthItem);
+	assert.ok(!(barWidthItem?.values ?? []).includes("fill"));
+});
+
+test("divider items switch between widget and status placement options", () => {
+	const settings = getDefaultSettings();
+
+	let items = buildDisplayDividerItems(settings);
+	assert.ok(items.some((item) => item.id === "showTopDivider"));
+	assert.ok(items.some((item) => item.id === "showBottomDivider"));
+	assert.ok(!items.some((item) => item.id === "statusLeadingDivider"));
+
+	settings.display.widgetPlacement = "status";
+	items = buildDisplayDividerItems(settings);
+	assert.ok(!items.some((item) => item.id === "showTopDivider"));
+	assert.ok(!items.some((item) => item.id === "showBottomDivider"));
+	assert.ok(items.some((item) => item.id === "statusLeadingDivider"));
+	assert.ok(items.some((item) => item.id === "statusTrailingDivider"));
+});
+
+test("applyDisplayChange toggles status edge dividers", () => {
+	const settings = getDefaultSettings();
+	applyDisplayChange(settings, "statusLeadingDivider", "on");
+	applyDisplayChange(settings, "statusTrailingDivider", "on");
+	assert.equal(settings.display.statusLeadingDivider, true);
+	assert.equal(settings.display.statusTrailingDivider, true);
 });
 
 test("decodeDisplayShareString rejects invalid payloads", () => {

--- a/packages/sub-status/.gitignore
+++ b/packages/sub-status/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+settings.json
+cache.json
+cache.lock

--- a/packages/sub-status/.npmignore
+++ b/packages/sub-status/.npmignore
@@ -1,0 +1,15 @@
+# never ship packed artifacts
+*.tgz
+
+# local install artifacts
+node_modules
+package-lock.json
+
+# local dev files
+settings.json
+.DS_Store
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/packages/sub-status/README.md
+++ b/packages/sub-status/README.md
@@ -1,0 +1,57 @@
+# sub-status
+
+Compact status-line client for [pi-coding-agent](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent).
+
+`sub-status` is a small passive companion to `sub-core`: it renders current quota usage via `ctx.ui.setStatus(...)`, without widget UI, commands, or settings UI in v1.
+
+On startup it follows the same bootstrap pattern as `sub-bar`, requests the current `sub-core` state, and then listens for `sub-core:ready` / `sub-core:update-current` to keep the compact line up to date. It stays deliberately quiet: no placeholder text when state is unavailable, and the status clears entirely when no usable usage snapshot exists.
+
+## Installation
+
+Install via the pi package manager:
+
+```bash
+pi install npm:@marckrenn/pi-sub-status
+```
+
+Use `-l` to install into project settings instead of global:
+
+```bash
+pi install -l npm:@marckrenn/pi-sub-status
+```
+
+`sub-status` follows the same package metadata/bootstrap pattern as `sub-bar`: it depends on `sub-core`, declares the same extra extension paths in package metadata, and probes/auto-loads `sub-core` at runtime for resilience.
+
+## Relationship to the other packages
+
+- `sub-core` is the shared source of truth for provider detection, fetching, cache/state, and events.
+- `sub-bar` is the rich widget UI and remains the default visual package.
+- `sub-status` is an optional compact client for status-line-friendly and RPC-friendly hosts.
+
+Installing `sub-status` alongside `sub-bar` is expected to be supported: `sub-bar` owns the rich widget, while `sub-status` owns a compact status line.
+
+## Current v1 scope
+
+- Shows windows only
+- Shows the first two windows only
+- Prefers reset descriptions when available, otherwise falls back to window labels
+- Shows percentages for each window
+- Appends compact stale / incident suffix text when relevant
+- Updates from `sub-core` startup/current-state events
+- Clears the status entirely when no usable current state exists
+
+## Not in v1
+
+- Commands
+- Settings UI
+- `setWidget`
+- `ctx.ui.custom(...)`
+- Provider/model labels in the compact line
+- Hybrid label + reset output in the compact line
+
+## Development
+
+```bash
+npm run check -w @marckrenn/pi-sub-status
+npm run test -w @marckrenn/pi-sub-status
+```

--- a/packages/sub-status/index.ts
+++ b/packages/sub-status/index.ts
@@ -1,0 +1,9 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { createStatusRuntime, type RuntimeDependencies } from "./src/runtime.js";
+
+/**
+ * Create the compact status-line client.
+ */
+export default function createExtension(pi: ExtensionAPI, dependencies?: RuntimeDependencies): void {
+	createStatusRuntime(pi, dependencies);
+}

--- a/packages/sub-status/package.json
+++ b/packages/sub-status/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@marckrenn/pi-sub-status",
+  "version": "1.3.0",
+  "description": "Compact status-line client for pi subscription usage",
+  "keywords": [
+    "pi-package"
+  ],
+  "type": "module",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts",
+      "node_modules/@marckrenn/pi-sub-core/index.ts",
+      "../pi-sub-core/index.ts"
+    ]
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "check:watch": "tsc --noEmit --watch",
+    "test": "tsx test/all.test.ts",
+    "test:watch": "tsx watch test/all.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.8.0"
+  },
+  "dependencies": {
+    "@marckrenn/pi-sub-core": "^1.3.0",
+    "@marckrenn/pi-sub-shared": "^1.3.0"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  }
+}

--- a/packages/sub-status/src/format.ts
+++ b/packages/sub-status/src/format.ts
@@ -1,0 +1,63 @@
+import type { ProviderStatus, RateWindow, UsageSnapshot } from "@marckrenn/pi-sub-shared";
+
+function clampPercent(value: number): number {
+	return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function formatWindow(window: RateWindow): string {
+	const percent = `${clampPercent(window.usedPercent)}%`;
+	const label = window.resetDescription?.trim() || window.label.trim();
+	return label ? `${label} ${percent}` : percent;
+}
+
+function mapIncident(status?: ProviderStatus): string | undefined {
+	if (!status || status.indicator === "none") return undefined;
+	switch (status.indicator) {
+		case "minor":
+			return "degraded";
+		case "major":
+		case "critical":
+			return "outage";
+		case "maintenance":
+			return "maintenance";
+		case "unknown":
+		default:
+			return "unknown";
+	}
+}
+
+function isStale(usage: UsageSnapshot): boolean {
+	return Boolean(usage.error && usage.lastSuccessAt);
+}
+
+function isSyntheticStaleStatus(usage: UsageSnapshot): boolean {
+	// sub-core currently uses a minor status with an elapsed description for stale fallback data.
+	return isStale(usage) && usage.status?.indicator === "minor";
+}
+
+/**
+ * Format the current usage snapshot into a compact status-line string.
+ */
+export function formatCompactStatus(usage: UsageSnapshot | undefined): string | undefined {
+	if (!usage || usage.windows.length === 0) {
+		return undefined;
+	}
+
+	const parts = usage.windows.slice(0, 2).map(formatWindow);
+	if (parts.length === 0) {
+		return undefined;
+	}
+
+	if (isStale(usage)) {
+		parts.push("stale");
+	}
+
+	if (!isSyntheticStaleStatus(usage)) {
+		const incident = mapIncident(usage.status);
+		if (incident) {
+			parts.push(incident);
+		}
+	}
+
+	return parts.join(" · ");
+}

--- a/packages/sub-status/src/runtime.ts
+++ b/packages/sub-status/src/runtime.ts
@@ -1,0 +1,181 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { SubCoreState } from "@marckrenn/pi-sub-shared";
+import { formatCompactStatus } from "./format.js";
+
+const STATUS_KEY = "sub-status:usage";
+const DEFAULT_PROBE_TIMEOUT_MS = 200;
+const DEFAULT_REQUEST_TIMEOUT_MS = 1000;
+
+type SubCoreRequest = {
+	type?: "current";
+	includeSettings?: boolean;
+	reply: (payload: { state: SubCoreState }) => void;
+};
+
+/**
+ * Optional dependencies for testing and runtime probing.
+ */
+export type RuntimeDependencies = {
+	probeTimeoutMs?: number;
+	requestTimeoutMs?: number;
+	importModule?: (specifier: string) => Promise<unknown>;
+	logWarning?: (message: string, error: unknown) => void;
+};
+
+function resolveTimeout(value: number | undefined, fallback: number): number {
+	return value ?? fallback;
+}
+
+function getCreateCore(module: unknown): ((api: ExtensionAPI) => void | Promise<void>) | undefined {
+	const candidate = (module as { default?: unknown }).default;
+	return typeof candidate === "function"
+		? (candidate as (api: ExtensionAPI) => void | Promise<void>)
+		: undefined;
+}
+
+function requestSubCoreCurrent<T>(
+	pi: ExtensionAPI,
+	timeoutMs: number,
+	onReply: (payload: { state: SubCoreState }) => T,
+	onTimeout: T
+): Promise<T> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			resolve(onTimeout);
+		}, timeoutMs);
+		timer.unref?.();
+
+		const request: SubCoreRequest = {
+			type: "current",
+			reply: (payload) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				resolve(onReply(payload));
+			},
+		};
+
+		pi.events.emit("sub-core:request", request);
+	});
+}
+
+function probeSubCore(pi: ExtensionAPI, timeoutMs: number): Promise<boolean> {
+	return requestSubCoreCurrent(pi, timeoutMs, () => true, false);
+}
+
+function requestCoreState(pi: ExtensionAPI, timeoutMs: number): Promise<SubCoreState | undefined> {
+	return requestSubCoreCurrent(pi, timeoutMs, (payload) => payload.state, undefined);
+}
+
+async function loadSubCoreFactory(
+	importModule: (specifier: string) => Promise<unknown>,
+	logWarning: (message: string, error: unknown) => void
+): Promise<((api: ExtensionAPI) => void | Promise<void>) | undefined> {
+	const specifiers = [new URL("../node_modules/@marckrenn/pi-sub-core/index.ts", import.meta.url).toString(), "@marckrenn/pi-sub-core"];
+	let failure: unknown = new Error("sub-core module did not export a default extension factory");
+
+	for (const specifier of specifiers) {
+		try {
+			const module = await importModule(specifier);
+			const createCore = getCreateCore(module);
+			if (createCore) {
+				return createCore;
+			}
+			failure = new Error(`${specifier} did not export a default extension factory`);
+		} catch (error) {
+			failure = error;
+		}
+	}
+
+	logWarning("Failed to auto-load sub-core", failure);
+	return undefined;
+}
+
+/**
+ * Wire sub-status into the sub-core event flow for the current pi session.
+ */
+export function createStatusRuntime(pi: ExtensionAPI, dependencies: RuntimeDependencies = {}): void {
+	let lastContext: ExtensionContext | undefined;
+	let lastRenderedStatus: string | undefined;
+	let subCoreBootstrapAttempted = false;
+	let currentStateVersion = 0;
+
+	const probeTimeoutMs = resolveTimeout(dependencies.probeTimeoutMs, DEFAULT_PROBE_TIMEOUT_MS);
+	const requestTimeoutMs = resolveTimeout(dependencies.requestTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS);
+	const importModule = dependencies.importModule ?? ((specifier: string) => import(specifier));
+	const logWarning = dependencies.logWarning ?? ((message: string, error: unknown) => console.warn(`${message}:`, error));
+
+	function renderStatus(ctx: ExtensionContext, state: SubCoreState | undefined): void {
+		const nextStatus = formatCompactStatus(state?.usage);
+		if (nextStatus === lastRenderedStatus) {
+			return;
+		}
+		ctx.ui.setStatus(STATUS_KEY, nextStatus);
+		lastRenderedStatus = nextStatus;
+	}
+
+	async function ensureSubCoreLoaded(): Promise<void> {
+		if (subCoreBootstrapAttempted) {
+			return;
+		}
+		subCoreBootstrapAttempted = true;
+
+		if (await probeSubCore(pi, probeTimeoutMs)) {
+			return;
+		}
+
+		const createCore = await loadSubCoreFactory(importModule, logWarning);
+		if (!createCore) {
+			return;
+		}
+		await createCore(pi);
+	}
+
+	function renderCurrentState(state: SubCoreState | undefined): void {
+		currentStateVersion += 1;
+		if (!lastContext) {
+			return;
+		}
+		renderStatus(lastContext, state);
+	}
+
+	pi.events.on("sub-core:ready", (payload) => {
+		const event = payload as { state?: SubCoreState };
+		renderCurrentState(event.state);
+	});
+
+	pi.events.on("sub-core:update-current", (payload) => {
+		const event = payload as { state?: SubCoreState };
+		renderCurrentState(event.state);
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		lastContext = ctx;
+		const requestStateVersion = currentStateVersion;
+
+		void (async () => {
+			await ensureSubCoreLoaded();
+			if (lastContext !== ctx) {
+				return;
+			}
+			const state = await requestCoreState(pi, requestTimeoutMs);
+			if (lastContext !== ctx || currentStateVersion !== requestStateVersion) {
+				return;
+			}
+			renderStatus(ctx, state);
+		})();
+	});
+
+	pi.on("session_shutdown", () => {
+		if (lastContext) {
+			renderStatus(lastContext, undefined);
+		}
+		lastContext = undefined;
+		lastRenderedStatus = undefined;
+		subCoreBootstrapAttempted = false;
+		currentStateVersion = 0;
+	});
+}

--- a/packages/sub-status/test/all.test.ts
+++ b/packages/sub-status/test/all.test.ts
@@ -1,0 +1,2 @@
+import "./formatting.test.js";
+import "./runtime.test.js";

--- a/packages/sub-status/test/formatting.test.ts
+++ b/packages/sub-status/test/formatting.test.ts
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { ProviderStatus, UsageSnapshot } from "@marckrenn/pi-sub-shared";
+import { formatCompactStatus } from "../src/format.js";
+
+function buildUsage(overrides?: Partial<UsageSnapshot>): UsageSnapshot {
+	return {
+		provider: "anthropic",
+		displayName: "Anthropic (Claude)",
+		windows: [
+			{ label: "5h", usedPercent: 3, resetDescription: "3h4m" },
+			{ label: "Week", usedPercent: 7, resetDescription: "6d11h" },
+			{ label: "Extra", usedPercent: 11, resetDescription: "Tomorrow" },
+		],
+		...overrides,
+	};
+}
+
+function withStatus(indicator: ProviderStatus["indicator"]): UsageSnapshot {
+	return buildUsage({ status: { indicator } });
+}
+
+test("formats the first two windows using reset descriptions when available", () => {
+	assert.equal(formatCompactStatus(buildUsage()), "3h4m 3% · 6d11h 7%");
+});
+
+test("falls back to the window label when reset description is missing", () => {
+	const usage = buildUsage({
+		windows: [
+			{ label: "5h", usedPercent: 3, resetDescription: "3h4m" },
+			{ label: "Week", usedPercent: 7 },
+		],
+	});
+
+	assert.equal(formatCompactStatus(usage), "3h4m 3% · Week 7%");
+});
+
+test("formats a single window without provider label noise", () => {
+	const usage = buildUsage({ windows: [{ label: "Month", usedPercent: 42 }] });
+
+	assert.equal(formatCompactStatus(usage), "Month 42%");
+});
+
+test("formats rounded percent after reset descriptions", () => {
+	const usage = buildUsage({ windows: [{ label: "Month", usedPercent: 42.6, resetDescription: "2d" }] });
+
+	assert.equal(formatCompactStatus(usage), "2d 43%");
+});
+
+test("appends stale suffix text for fallback data", () => {
+	const usage = buildUsage({
+		error: { code: "FETCH_FAILED", message: "Fetch failed" },
+		lastSuccessAt: Date.now() - 60_000,
+	});
+
+	assert.equal(formatCompactStatus(usage), "3h4m 3% · 6d11h 7% · stale");
+});
+
+test("maps minor incidents to degraded suffix text", () => {
+	assert.equal(formatCompactStatus(withStatus("minor")), "3h4m 3% · 6d11h 7% · degraded");
+});
+
+test("maps major incidents to outage suffix text", () => {
+	assert.equal(formatCompactStatus(withStatus("major")), "3h4m 3% · 6d11h 7% · outage");
+});
+
+test("maps critical incidents to outage suffix text", () => {
+	assert.equal(formatCompactStatus(withStatus("critical")), "3h4m 3% · 6d11h 7% · outage");
+});
+
+test("maps maintenance incidents to maintenance suffix text", () => {
+	assert.equal(formatCompactStatus(withStatus("maintenance")), "3h4m 3% · 6d11h 7% · maintenance");
+});
+
+test("maps unknown incidents to unknown suffix text", () => {
+	assert.equal(formatCompactStatus(withStatus("unknown")), "3h4m 3% · 6d11h 7% · unknown");
+});
+
+test("does not append noise for operational status", () => {
+	assert.equal(formatCompactStatus(withStatus("none")), "3h4m 3% · 6d11h 7%");
+});
+
+test("stale fallback suppresses synthetic incident text", () => {
+	const usage = buildUsage({
+		status: { indicator: "minor", description: "5m ago" },
+		error: { code: "FETCH_FAILED", message: "Fetch failed" },
+		lastSuccessAt: Date.now() - 60_000,
+	});
+
+	assert.equal(formatCompactStatus(usage), "3h4m 3% · 6d11h 7% · stale");
+});
+
+test("formats combined stale and real incident suffixes when both are present", () => {
+	const usage = buildUsage({
+		status: { indicator: "maintenance" },
+		error: { code: "HTTP_ERROR", message: "HTTP 500", httpStatus: 500 },
+		lastSuccessAt: Date.now() - 60_000,
+	});
+
+	assert.equal(formatCompactStatus(usage), "3h4m 3% · 6d11h 7% · stale · maintenance");
+});
+
+test("returns undefined for missing usage", () => {
+	assert.equal(formatCompactStatus(undefined), undefined);
+});
+
+test("returns undefined for usage with no windows", () => {
+	assert.equal(formatCompactStatus(buildUsage({ windows: [] })), undefined);
+});

--- a/packages/sub-status/test/runtime.test.ts
+++ b/packages/sub-status/test/runtime.test.ts
@@ -1,0 +1,321 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createEventBus, type ExtensionAPI, type ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { SubCoreState, UsageSnapshot } from "@marckrenn/pi-sub-shared";
+import { createStatusRuntime } from "../src/runtime.js";
+
+type StatusCall = {
+	key: string;
+	text: string | undefined;
+};
+
+type WarningCall = {
+	message: string;
+	error: unknown;
+};
+
+type CallLog<T> = {
+	calls: T[];
+	push: (value: T) => void;
+	waitForCount: (count: number, timeoutMs?: number) => Promise<void>;
+};
+
+type FakePi = ExtensionAPI & {
+	commands: string[];
+	emitEvent: (event: string, ctx: ExtensionContext) => Promise<void>;
+};
+
+function buildUsage(overrides?: Partial<UsageSnapshot>): UsageSnapshot {
+	return {
+		provider: "anthropic",
+		displayName: "Anthropic (Claude)",
+		windows: [
+			{ label: "5h", usedPercent: 3, resetDescription: "3h4m" },
+			{ label: "Week", usedPercent: 7, resetDescription: "6d11h" },
+		],
+		...overrides,
+	};
+}
+
+function createCallLog<T>(): CallLog<T> {
+	const calls: T[] = [];
+	const waiters = new Set<() => void>();
+
+	return {
+		calls,
+		push(value) {
+			calls.push(value);
+			for (const resolve of waiters) {
+				resolve();
+			}
+		},
+		async waitForCount(count: number, timeoutMs = 200) {
+			if (calls.length >= count) {
+				return;
+			}
+
+			await new Promise<void>((resolve, reject) => {
+				const timer = setTimeout(() => {
+					waiters.delete(checkCount);
+					reject(new Error(`condition not met within ${timeoutMs}ms`));
+				}, timeoutMs);
+
+				const checkCount = () => {
+					if (calls.length < count) {
+						return;
+					}
+					clearTimeout(timer);
+					waiters.delete(checkCount);
+					resolve();
+				};
+
+				waiters.add(checkCount);
+			});
+		},
+	};
+}
+
+function createContext(options?: { hasUI?: boolean }): { ctx: ExtensionContext; statusCalls: StatusCall[]; waitForStatusCalls: (count: number, timeoutMs?: number) => Promise<void> } {
+	const statusLog = createCallLog<StatusCall>();
+	const ctx = {
+		ui: {
+			select: async () => undefined,
+			confirm: async () => false,
+			input: async () => undefined,
+			notify: () => {},
+			setStatus: (key: string, text: string | undefined) => {
+				statusLog.push({ key, text });
+			},
+			setWorkingMessage: () => {},
+			setWidget: () => {},
+			setFooter: () => {},
+			setHeader: () => {},
+			setTitle: () => {},
+			custom: async () => undefined,
+			setEditorText: () => {},
+		},
+		hasUI: options?.hasUI ?? false,
+		cwd: "/tmp/project",
+		sessionManager: {} as ExtensionContext["sessionManager"],
+		modelRegistry: {} as ExtensionContext["modelRegistry"],
+		model: undefined,
+		isIdle: () => true,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+	} as ExtensionContext;
+
+	return { ctx, statusCalls: statusLog.calls, waitForStatusCalls: statusLog.waitForCount };
+}
+
+function createFakePi(): FakePi {
+	const handlers = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>();
+	const commands: string[] = [];
+
+	const pi = {
+		events: createEventBus(),
+		commands,
+		on(event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) {
+			const current = handlers.get(event) ?? [];
+			current.push(handler);
+			handlers.set(event, current);
+		},
+		async emitEvent(event: string, ctx: ExtensionContext) {
+			for (const handler of handlers.get(event) ?? []) {
+				await handler({ type: event }, ctx);
+			}
+		},
+		registerCommand(name: string) {
+			commands.push(name);
+		},
+		registerTool: () => {
+			throw new Error("registerTool should not be called by sub-status");
+		},
+		registerShortcut: () => {
+			throw new Error("registerShortcut should not be called by sub-status");
+		},
+		registerFlag: () => {},
+		getFlag: () => undefined,
+		registerMessageRenderer: () => {},
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		appendEntry: () => {},
+		setSessionName: () => {},
+		getSessionName: () => undefined,
+		setLabel: () => {},
+		exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		setActiveTools: () => {},
+		setModel: async () => true,
+		getThinkingLevel: () => "high",
+		setThinkingLevel: () => {},
+		registerProvider: () => {},
+	} as unknown as FakePi;
+
+	return pi;
+}
+
+function registerCurrentStateReply(pi: FakePi, state: SubCoreState): void {
+	pi.events.on("sub-core:request", (payload) => {
+		const request = payload as { reply: (payload: { state: SubCoreState }) => void };
+		request.reply({ state });
+	});
+}
+
+function createDeferred<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+} {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+test("requests current state on startup and renders compact status without UI gating", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls, waitForStatusCalls } = createContext({ hasUI: false });
+	registerCurrentStateReply(pi, { usage: buildUsage() });
+
+	createStatusRuntime(pi);
+	await pi.emitEvent("session_start", ctx);
+	await waitForStatusCalls(1);
+
+	assert.deepEqual(statusCalls, [{ key: "sub-status:usage", text: "3h4m 3% · 6d11h 7%" }]);
+	assert.deepEqual(pi.commands, []);
+});
+
+test("updates the status on sub-core:update-current and suppresses duplicate writes", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls, waitForStatusCalls } = createContext();
+	registerCurrentStateReply(pi, { usage: buildUsage() });
+
+	createStatusRuntime(pi);
+	await pi.emitEvent("session_start", ctx);
+	await waitForStatusCalls(1);
+
+	pi.events.emit("sub-core:update-current", { state: { usage: buildUsage({ windows: [{ label: "Month", usedPercent: 42 }] }) } });
+	await waitForStatusCalls(2);
+	pi.events.emit("sub-core:update-current", { state: { usage: buildUsage({ windows: [{ label: "Month", usedPercent: 42 }] }) } });
+
+	assert.deepEqual(statusCalls, [
+		{ key: "sub-status:usage", text: "3h4m 3% · 6d11h 7%" },
+		{ key: "sub-status:usage", text: "Month 42%" },
+	]);
+});
+
+test("clears the status when current state becomes unusable and on session shutdown", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls, waitForStatusCalls } = createContext();
+	registerCurrentStateReply(pi, { usage: buildUsage() });
+
+	createStatusRuntime(pi);
+	await pi.emitEvent("session_start", ctx);
+	await waitForStatusCalls(1);
+
+	pi.events.emit("sub-core:update-current", { state: { usage: buildUsage({ windows: [] }) } });
+	await waitForStatusCalls(2);
+	await pi.emitEvent("session_shutdown", ctx);
+
+	assert.deepEqual(statusCalls, [
+		{ key: "sub-status:usage", text: "3h4m 3% · 6d11h 7%" },
+		{ key: "sub-status:usage", text: undefined },
+	]);
+});
+
+test("keeps a newer sub-core ready update when the startup request replies later with stale state", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls, waitForStatusCalls } = createContext();
+	const startupRequest = createDeferred<{ reply: (payload: { state: SubCoreState }) => void }>();
+	let requestCount = 0;
+
+	pi.events.on("sub-core:request", (payload) => {
+		const request = payload as { reply: (payload: { state: SubCoreState }) => void };
+		requestCount += 1;
+		if (requestCount === 1) {
+			request.reply({ state: {} });
+			return;
+		}
+		startupRequest.resolve(request);
+	});
+
+	createStatusRuntime(pi, { probeTimeoutMs: 1, requestTimeoutMs: 50 });
+	await pi.emitEvent("session_start", ctx);
+	const delayedRequest = await startupRequest.promise;
+
+	pi.events.emit("sub-core:ready", { state: { usage: buildUsage() } });
+	await waitForStatusCalls(1);
+	assert.deepEqual(statusCalls, [{ key: "sub-status:usage", text: "3h4m 3% · 6d11h 7%" }]);
+
+	delayedRequest.reply({ state: {} });
+	await new Promise((resolve) => setImmediate(resolve));
+
+	assert.deepEqual(statusCalls, [{ key: "sub-status:usage", text: "3h4m 3% · 6d11h 7%" }]);
+});
+
+test("tries bundled sub-core first and falls back to package resolution when probing fails", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls, waitForStatusCalls } = createContext();
+	const imports: string[] = [];
+
+	const importModule = async (specifier: string): Promise<unknown> => {
+		imports.push(specifier);
+		if (specifier.includes("node_modules/@marckrenn/pi-sub-core/index.ts")) {
+			throw new Error("missing bundled core");
+		}
+		if (specifier === "@marckrenn/pi-sub-core") {
+			return {
+				default(api: ExtensionAPI) {
+					(api.events as FakePi["events"]).on("sub-core:request", (payload) => {
+						const request = payload as { reply: (payload: { state: SubCoreState }) => void };
+						request.reply({ state: { usage: buildUsage({ windows: [{ label: "Month", usedPercent: 42 }] }) } });
+					});
+				},
+			};
+		}
+		throw new Error(`unexpected import: ${specifier}`);
+	};
+
+	createStatusRuntime(pi, {
+		probeTimeoutMs: 1,
+		requestTimeoutMs: 1,
+		importModule,
+	});
+	await pi.emitEvent("session_start", ctx);
+	await waitForStatusCalls(1);
+
+	assert.ok(imports[0].includes("node_modules/@marckrenn/pi-sub-core/index.ts"));
+	assert.equal(imports[1], "@marckrenn/pi-sub-core");
+	assert.deepEqual(statusCalls, [{ key: "sub-status:usage", text: "Month 42%" }]);
+});
+
+test("warns once when sub-core cannot be auto-loaded from either runtime import path", async () => {
+	const pi = createFakePi();
+	const { ctx, statusCalls } = createContext();
+	const warningLog = createCallLog<WarningCall>();
+	const importLog = createCallLog<string>();
+
+	const importModule = async (specifier: string): Promise<unknown> => {
+		importLog.push(specifier);
+		return {};
+	};
+
+	createStatusRuntime(pi, {
+		probeTimeoutMs: 1,
+		requestTimeoutMs: 1,
+		importModule,
+		logWarning: (message, error) => warningLog.push({ message, error }),
+	});
+	await pi.emitEvent("session_start", ctx);
+	await warningLog.waitForCount(1);
+	await importLog.waitForCount(2);
+
+	assert.equal(warningLog.calls[0].message, "Failed to auto-load sub-core");
+	assert.equal(importLog.calls[1], "@marckrenn/pi-sub-core");
+	assert.deepEqual(statusCalls, []);
+});

--- a/packages/sub-status/tsconfig.json
+++ b/packages/sub-status/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## release-1.4.0 scope

This PR now includes all work currently on `release-1.4.0`, which is no longer limited to sub-status only.

### Included changes
- Add compact status-line package `sub-status` (implementation + tests) and related docs/workflow updates for release packaging.
- Add built-in **Default Footer** theme preset (status widget layout preset) in `sub-bar`.
- Finalize status-line placement behavior in `sub-bar` (status mode defaults/normalization, truncation/alignment handling, status-safe padding behavior, and related UI controls/menus).
- Add support for transparent widget background (`backgroundColor: none`) and set bundled defaults to transparent.

### Included PRs
- **PR #48**: add compact `sub-status` package and release-package plumbing.
- **PR #44**: status-line behavior/placement behavior changes (cherry-picked into this branch).
- **PR #47**: transparent background option support (`backgroundColor: none`) with tests.

### Notes
- Release note changesets currently in this branch include:
  - `bright-suns-sing.md` (1.2.0 API-auth fix)
  - `odd-moose-float.md` (status-line placement behavior)
  - `quiet-ears-smell.md` (Default Footer preset)
  - `transparent-bg-option.md` (transparent background behavior)
  - `empty-suns-juggle.md` (bundle defaults use `backgroundColor: none`)
- This PR is intended to represent the full `release-1.4.0` set before merge to `main`.



Closes #46
