### PR TITLE
release: align bar/core/shared to 1.4.0 lockstep

### DIFF
--- a/.changeset/lockstep-fourteen.md
+++ b/.changeset/lockstep-fourteen.md
@@ -1,0 +1,9 @@
+---
+"@marckrenn/pi-sub-bar": minor
+"@marckrenn/pi-sub-core": minor
+"@marckrenn/pi-sub-shared": minor
+---
+
+Align `sub-bar`, `sub-core`, and `sub-shared` to `1.4.0` in lockstep.
+
+No functional changes in this bump; this release normalizes package versions after the previous publish.


### PR DESCRIPTION
## Summary
- add a changeset to bump the fixed group packages to **1.4.0** in lockstep
- this aligns `@marckrenn/pi-sub-bar`, `@marckrenn/pi-sub-core`, and `@marckrenn/pi-sub-shared` with the intended 1.4.0 release line

## Notes
- no functional code changes
- this is a version-alignment follow-up after #49/#50
