### PR TITLE
fix(sub-status): show spark quota for codex-spark users

### DIFF
--- a/packages/sub-core/index.ts
+++ b/packages/sub-core/index.ts
@@ -13,6 +13,7 @@ import { createUsageController, type UsageUpdate } from "./src/usage/controller.
 import { fetchUsageEntries, getCachedUsageEntries } from "./src/usage/fetch.js";
 import { onCacheSnapshot, onCacheUpdate, watchCacheUpdates, type Cache } from "./src/cache.js";
 import { isExpectedMissingData } from "./src/errors.js";
+import { prioritizeWindowsForModel } from "./src/utils.js";
 import { getStorage } from "./src/storage.js";
 import { clearSettingsCache, loadSettings, saveSettings, SETTINGS_PATH } from "./src/settings.js";
 import { showSettingsUI } from "./src/settings-ui.js";
@@ -108,7 +109,11 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 	let lastCurrentSnapshot = "";
 
 	const emitCurrentUpdate = (provider?: ProviderName, usage?: UsageSnapshot): void => {
-		lastState = { provider, usage };
+		const model = lastContext?.model;
+		const sorted = usage && model
+			? { ...usage, windows: prioritizeWindowsForModel(usage.windows, model) }
+			: usage;
+		lastState = { provider, usage: sorted };
 		const payload = JSON.stringify(lastState);
 		if (payload === lastCurrentSnapshot) return;
 		lastCurrentSnapshot = payload;

--- a/packages/sub-core/src/utils.ts
+++ b/packages/sub-core/src/utils.ts
@@ -2,7 +2,7 @@
  * Utility functions for the sub-bar extension
  */
 
-import type { Dependencies } from "./types.js";
+import type { Dependencies, RateWindow } from "./types.js";
 import { MODEL_MULTIPLIERS } from "./config.js";
 
 // Only allow simple CLI names (no spaces/paths) to avoid unsafe command execution.
@@ -63,6 +63,42 @@ export function normalizeTokens(value: string): string[] {
 		.trim()
 		.split(" ")
 		.filter(Boolean);
+}
+
+/**
+ * Reorder usage windows so those matching the active model come first.
+ * A window matches when every model-ID token appears in the window label
+ * AND the model tokens form a strict majority of the label tokens.
+ * The majority check prevents a short model name (e.g. "gpt-5.3") from
+ * falsely matching a longer, more specific label (e.g. "GPT-5.3-Codex-Spark 5h").
+ * Non-matching windows keep their original relative order.
+ */
+export function prioritizeWindowsForModel(
+	windows: RateWindow[],
+	model?: { id?: string } | null,
+): RateWindow[] {
+	if (!model?.id || windows.length <= 1) return windows;
+
+	const modelTokens = normalizeTokens(model.id);
+	if (modelTokens.length === 0) return windows;
+
+	const matched: RateWindow[] = [];
+	const rest: RateWindow[] = [];
+
+	for (const window of windows) {
+		const labelTokens = normalizeTokens(window.label);
+		const isMatch = modelTokens.every((token) => labelTokens.includes(token))
+			&& modelTokens.length * 2 > labelTokens.length;
+		if (isMatch) {
+			matched.push(window);
+		} else {
+			rest.push(window);
+		}
+	}
+
+	if (matched.length === 0 || matched.length === windows.length) return windows;
+
+	return [...matched, ...rest];
 }
 
 // Pre-computed token entries for model multiplier matching

--- a/packages/sub-core/test/all.test.ts
+++ b/packages/sub-core/test/all.test.ts
@@ -1,5 +1,6 @@
 import "./detection.test.js";
 import "./providers.test.js";
+import "./prioritize.test.js";
 import "./controller.test.js";
 import "./cache.test.js";
 import "./lock.test.js";

--- a/packages/sub-core/test/prioritize.test.ts
+++ b/packages/sub-core/test/prioritize.test.ts
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { RateWindow } from "../src/types.js";
+import { prioritizeWindowsForModel } from "../src/utils.js";
+
+function window(label: string, usedPercent = 0): RateWindow {
+	return { label, usedPercent };
+}
+
+test("codex spark windows are moved before general windows", () => {
+	const windows = [
+		window("5h", 0),
+		window("Week", 1),
+		window("GPT-5.3-Codex-Spark 5h", 2),
+		window("GPT-5.3-Codex-Spark Week", 3),
+	];
+
+	const result = prioritizeWindowsForModel(windows, { id: "gpt-5.3-codex-spark" });
+
+	assert.deepEqual(
+		result.map((w) => w.label),
+		["GPT-5.3-Codex-Spark 5h", "GPT-5.3-Codex-Spark Week", "5h", "Week"],
+	);
+});
+
+test("antigravity current model window is moved first", () => {
+	const windows = [
+		window("Gemini 2.5 Pro"),
+		window("Gemini 3 Flash"),
+		window("Gemini 3 Pro"),
+		window("Gemini 3.5 Flash"),
+	];
+
+	const result = prioritizeWindowsForModel(windows, { id: "gemini-3-pro" });
+
+	assert.deepEqual(
+		result.map((w) => w.label),
+		["Gemini 3 Pro", "Gemini 2.5 Pro", "Gemini 3 Flash", "Gemini 3.5 Flash"],
+	);
+});
+
+test("returns original array when no windows match the model", () => {
+	const windows = [window("5h"), window("Week")];
+
+	const result = prioritizeWindowsForModel(windows, { id: "claude-3.5-sonnet" });
+
+	assert.equal(result, windows);
+});
+
+test("returns original array when all windows match", () => {
+	const windows = [
+		window("GPT-5.3-Codex-Spark 5h"),
+		window("GPT-5.3-Codex-Spark Week"),
+	];
+
+	const result = prioritizeWindowsForModel(windows, { id: "gpt-5.3-codex-spark" });
+
+	assert.equal(result, windows);
+});
+
+test("non-spark codex model does not match spark windows", () => {
+	const windows = [
+		window("5h", 0),
+		window("Week", 1),
+		window("GPT-5.3-Codex-Spark 5h", 2),
+		window("GPT-5.3-Codex-Spark Week", 3),
+	];
+
+	const result = prioritizeWindowsForModel(windows, { id: "gpt-5.3" });
+
+	assert.equal(result, windows);
+});
+
+test("returns original array when model is absent", () => {
+	const windows = [window("5h"), window("Week")];
+
+	assert.equal(prioritizeWindowsForModel(windows, undefined), windows);
+	assert.equal(prioritizeWindowsForModel(windows, null), windows);
+	assert.equal(prioritizeWindowsForModel(windows, { id: undefined }), windows);
+	assert.equal(prioritizeWindowsForModel(windows, { id: "" }), windows);
+});


### PR DESCRIPTION
Codex-spark users saw their general (non-spark) quota in the compact status line instead of their spark-specific quota. The API returns general windows first, and sub-status picks the first two.

Reorder windows in sub-core so those matching the active model come first. Also benefits antigravity users who previously saw whichever model happened to sort first alphabetically.

## What changed

- **`sub-core/src/utils.ts`**: added `prioritizeWindowsForModel()` — reorders windows so those matching the active model come first. A window matches when every model-ID token appears in the window label and the model tokens form a strict majority of the label tokens (prevents short model names like `gpt-5.3` from falsely matching longer labels like `GPT-5.3-Codex-Spark 5h`).

- **`sub-core/index.ts`**: applied in `emitCurrentUpdate`, the single funnel for all `sub-core:update-current` emissions (covers both the controller path and cross-process cache updates).

- **`sub-core/test/prioritize.test.ts`**: 6 tests covering spark reordering, antigravity reordering, false-positive prevention, and edge cases.

## What was NOT changed

- **sub-bar** — unaffected. Its existing visibility filtering and label stripping continue to work correctly on the reordered windows.
- **sub-status** — unaffected. Its `windows.slice(0, 2)` now naturally picks the right windows.

## Verified with real cached data

```
BEFORE fix:  sub-status: "1h54m 7% · 2d6h 51%"  (general quota)
AFTER fix:   sub-status: "4h59m 0% · 6d23h 0%"   (spark quota ✓)
sub-bar:     "Codex (Spark) │ 5h 4h59m left ━━ 0% used │ Week 6d23h left ━━ 0% used"  ✓
```

Closes #53