### PR TITLE
release-1.5.0: spark-window fix + lockstep package bump

### DIFF
--- a/.changeset/swift-cobras-juggle.md
+++ b/.changeset/swift-cobras-juggle.md
@@ -1,0 +1,10 @@
+---
+"@marckrenn/pi-sub-bar": minor
+"@marckrenn/pi-sub-core": minor
+"@marckrenn/pi-sub-shared": minor
+"@marckrenn/pi-sub-status": minor
+---
+
+Prioritize usage windows that match the active model before emitting `sub-core:update-current`, so compact status clients show the correct quota windows (including Codex Spark and Antigravity model-specific windows).
+
+Thanks [@dnouri](https://github.com/dnouri) for [#54](https://github.com/marckrenn/pi-sub/pull/54).

--- a/.changeset/swift-cobras-juggle.md
+++ b/.changeset/swift-cobras-juggle.md
@@ -7,4 +7,6 @@
 
 Prioritize usage windows that match the active model before emitting `sub-core:update-current`, so compact status clients show the correct quota windows (including Codex Spark and Antigravity model-specific windows).
 
+Also make settings list navigation compatible with both old and new `@mariozechner/pi-tui` keybinding APIs, preventing crashes in submenus on older Pi runtimes where `getEditorKeybindings()` is unavailable.
+
 Thanks [@dnouri](https://github.com/dnouri) for [#54](https://github.com/marckrenn/pi-sub/pull/54).

--- a/packages/sub-bar/src/ui/keybindings.ts
+++ b/packages/sub-bar/src/ui/keybindings.ts
@@ -1,0 +1,92 @@
+import * as PiTui from "@mariozechner/pi-tui";
+
+export type SettingsListAction =
+	| "selectUp"
+	| "selectDown"
+	| "cursorLeft"
+	| "cursorRight"
+	| "selectConfirm"
+	| "selectCancel";
+
+export interface SettingsKeybindings {
+	matches(data: string, action: SettingsListAction): boolean;
+}
+
+interface CompatibleApi {
+	getEditorKeybindings?: () => { matches(data: string, action: string): boolean };
+	getKeybindings?: () => { matches(data: string, action: string): boolean };
+	matchesKey?: (data: string, key: string) => boolean;
+}
+
+const LEGACY_ACTION_MAP: Record<SettingsListAction, string> = {
+	selectUp: "tui.select.up",
+	selectDown: "tui.select.down",
+	cursorLeft: "tui.editor.cursorLeft",
+	cursorRight: "tui.editor.cursorRight",
+	selectConfirm: "tui.select.confirm",
+	selectCancel: "tui.select.cancel",
+};
+
+const DEFAULT_ACTION_KEYS: Record<SettingsListAction, string | string[]> = {
+	selectUp: "up",
+	selectDown: "down",
+	cursorLeft: ["left", "ctrl+b"],
+	cursorRight: ["right", "ctrl+f"],
+	selectConfirm: "enter",
+	selectCancel: ["escape", "ctrl+c"],
+};
+
+function matchesKeyWithFallback(
+	data: string,
+	key: string,
+	matchesKey?: (data: string, key: string) => boolean,
+): boolean {
+	if (matchesKey) {
+		return matchesKey(data, key);
+	}
+
+	if (key === "enter") return data === "\r" || data === "\n";
+	if (key === "escape") return data === "\u001b";
+	if (key === "up") return data === "\u001b[A";
+	if (key === "down") return data === "\u001b[B";
+	if (key === "left") return data === "\u001b[D";
+	if (key === "right") return data === "\u001b[C";
+	return data === key;
+}
+
+function matchesDefaultAction(
+	data: string,
+	action: SettingsListAction,
+	matchesKey?: (data: string, key: string) => boolean,
+): boolean {
+	const keys = DEFAULT_ACTION_KEYS[action];
+	const list = Array.isArray(keys) ? keys : [keys];
+	return list.some((key) => matchesKeyWithFallback(data, key, matchesKey));
+}
+
+export function createSettingsKeybindings(api: CompatibleApi): SettingsKeybindings {
+	const editor = api.getEditorKeybindings?.();
+	if (editor && typeof editor.matches === "function") {
+		return {
+			matches: (data, action) => editor.matches(data, action),
+		};
+	}
+
+	const legacy = api.getKeybindings?.();
+	if (legacy && typeof legacy.matches === "function") {
+		return {
+			matches: (data, action) => {
+				const legacyAction = LEGACY_ACTION_MAP[action];
+				return legacy.matches(data, legacyAction);
+			},
+		};
+	}
+
+	return {
+		matches: (data, action) => matchesDefaultAction(data, action, api.matchesKey),
+	};
+}
+
+export function getSettingsKeybindings(): SettingsKeybindings {
+	return createSettingsKeybindings(PiTui as CompatibleApi);
+}

--- a/packages/sub-bar/src/ui/settings-list.ts
+++ b/packages/sub-bar/src/ui/settings-list.ts
@@ -2,11 +2,11 @@ import type { Component, SettingItem, SettingsListTheme } from "@mariozechner/pi
 import {
 	Input,
 	fuzzyFilter,
-	getEditorKeybindings,
 	truncateToWidth,
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@mariozechner/pi-tui";
+import { getSettingsKeybindings } from "./keybindings.js";
 
 export interface SettingsListOptions {
 	enableSearch?: boolean;
@@ -184,7 +184,7 @@ export class SettingsList implements Component {
 			return;
 		}
 
-		const kb = getEditorKeybindings();
+		const kb = getSettingsKeybindings();
 		const displayItems = this.searchEnabled ? this.filteredItems : this.items;
 
 		if (kb.matches(data, "selectUp")) {

--- a/packages/sub-bar/test/all.test.ts
+++ b/packages/sub-bar/test/all.test.ts
@@ -3,3 +3,4 @@ import "./settings.test.js";
 import "./dividers.test.js";
 import "./providers.test.js";
 import "./status.test.js";
+import "./keybindings.test.js";

--- a/packages/sub-bar/test/keybindings.test.ts
+++ b/packages/sub-bar/test/keybindings.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createSettingsKeybindings } from "../src/ui/keybindings.js";
+
+test("settings keybindings prefer editor keybindings when available", () => {
+	const kb = createSettingsKeybindings({
+		getEditorKeybindings: () => ({
+			matches: (data, action) => data === "X" && action === "selectDown",
+		}),
+		getKeybindings: () => ({
+			matches: () => {
+				throw new Error("legacy keybindings should not be used when editor keybindings exist");
+			},
+		}),
+	});
+
+	assert.equal(kb.matches("X", "selectDown"), true);
+	assert.equal(kb.matches("X", "selectUp"), false);
+});
+
+test("settings keybindings map actions to legacy keybinding IDs", () => {
+	const seen: string[] = [];
+	const kb = createSettingsKeybindings({
+		getKeybindings: () => ({
+			matches: (_data, action) => {
+				seen.push(action);
+				return action === "tui.select.down";
+			},
+		}),
+	});
+
+	assert.equal(kb.matches("ignored", "selectDown"), true);
+	assert.equal(kb.matches("ignored", "cursorLeft"), false);
+	assert.deepEqual(seen, ["tui.select.down", "tui.editor.cursorLeft"]);
+});
+
+test("settings keybindings fallback uses matchesKey helper when no keybinding manager exists", () => {
+	const kb = createSettingsKeybindings({
+		matchesKey: (data, key) => data === `<<${key}>>`,
+	});
+
+	assert.equal(kb.matches("<<up>>", "selectUp"), true);
+	assert.equal(kb.matches("<<down>>", "selectDown"), true);
+	assert.equal(kb.matches("<<left>>", "cursorLeft"), true);
+	assert.equal(kb.matches("<<enter>>", "selectConfirm"), true);
+	assert.equal(kb.matches("<<escape>>", "selectCancel"), true);
+	assert.equal(kb.matches("<<right>>", "cursorLeft"), false);
+});
+
+test("settings keybindings fallback handles raw escape sequences", () => {
+	const kb = createSettingsKeybindings({});
+
+	assert.equal(kb.matches("\u001b[A", "selectUp"), true);
+	assert.equal(kb.matches("\u001b[B", "selectDown"), true);
+	assert.equal(kb.matches("\u001b[D", "cursorLeft"), true);
+	assert.equal(kb.matches("\u001b[C", "cursorRight"), true);
+	assert.equal(kb.matches("\r", "selectConfirm"), true);
+	assert.equal(kb.matches("\u001b", "selectCancel"), true);
+});

--- a/packages/sub-core/index.ts
+++ b/packages/sub-core/index.ts
@@ -13,6 +13,7 @@ import { createUsageController, type UsageUpdate } from "./src/usage/controller.
 import { fetchUsageEntries, getCachedUsageEntries } from "./src/usage/fetch.js";
 import { onCacheSnapshot, onCacheUpdate, watchCacheUpdates, type Cache } from "./src/cache.js";
 import { isExpectedMissingData } from "./src/errors.js";
+import { prioritizeWindowsForModel } from "./src/utils.js";
 import { getStorage } from "./src/storage.js";
 import { clearSettingsCache, loadSettings, saveSettings, SETTINGS_PATH } from "./src/settings.js";
 import { showSettingsUI } from "./src/settings-ui.js";
@@ -108,7 +109,11 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 	let lastCurrentSnapshot = "";
 
 	const emitCurrentUpdate = (provider?: ProviderName, usage?: UsageSnapshot): void => {
-		lastState = { provider, usage };
+		const model = lastContext?.model;
+		const sorted = usage && model
+			? { ...usage, windows: prioritizeWindowsForModel(usage.windows, model) }
+			: usage;
+		lastState = { provider, usage: sorted };
 		const payload = JSON.stringify(lastState);
 		if (payload === lastCurrentSnapshot) return;
 		lastCurrentSnapshot = payload;

--- a/packages/sub-core/src/ui/keybindings.ts
+++ b/packages/sub-core/src/ui/keybindings.ts
@@ -1,0 +1,92 @@
+import * as PiTui from "@mariozechner/pi-tui";
+
+export type SettingsListAction =
+	| "selectUp"
+	| "selectDown"
+	| "cursorLeft"
+	| "cursorRight"
+	| "selectConfirm"
+	| "selectCancel";
+
+export interface SettingsKeybindings {
+	matches(data: string, action: SettingsListAction): boolean;
+}
+
+interface CompatibleApi {
+	getEditorKeybindings?: () => { matches(data: string, action: string): boolean };
+	getKeybindings?: () => { matches(data: string, action: string): boolean };
+	matchesKey?: (data: string, key: string) => boolean;
+}
+
+const LEGACY_ACTION_MAP: Record<SettingsListAction, string> = {
+	selectUp: "tui.select.up",
+	selectDown: "tui.select.down",
+	cursorLeft: "tui.editor.cursorLeft",
+	cursorRight: "tui.editor.cursorRight",
+	selectConfirm: "tui.select.confirm",
+	selectCancel: "tui.select.cancel",
+};
+
+const DEFAULT_ACTION_KEYS: Record<SettingsListAction, string | string[]> = {
+	selectUp: "up",
+	selectDown: "down",
+	cursorLeft: ["left", "ctrl+b"],
+	cursorRight: ["right", "ctrl+f"],
+	selectConfirm: "enter",
+	selectCancel: ["escape", "ctrl+c"],
+};
+
+function matchesKeyWithFallback(
+	data: string,
+	key: string,
+	matchesKey?: (data: string, key: string) => boolean,
+): boolean {
+	if (matchesKey) {
+		return matchesKey(data, key);
+	}
+
+	if (key === "enter") return data === "\r" || data === "\n";
+	if (key === "escape") return data === "\u001b";
+	if (key === "up") return data === "\u001b[A";
+	if (key === "down") return data === "\u001b[B";
+	if (key === "left") return data === "\u001b[D";
+	if (key === "right") return data === "\u001b[C";
+	return data === key;
+}
+
+function matchesDefaultAction(
+	data: string,
+	action: SettingsListAction,
+	matchesKey?: (data: string, key: string) => boolean,
+): boolean {
+	const keys = DEFAULT_ACTION_KEYS[action];
+	const list = Array.isArray(keys) ? keys : [keys];
+	return list.some((key) => matchesKeyWithFallback(data, key, matchesKey));
+}
+
+export function createSettingsKeybindings(api: CompatibleApi): SettingsKeybindings {
+	const editor = api.getEditorKeybindings?.();
+	if (editor && typeof editor.matches === "function") {
+		return {
+			matches: (data, action) => editor.matches(data, action),
+		};
+	}
+
+	const legacy = api.getKeybindings?.();
+	if (legacy && typeof legacy.matches === "function") {
+		return {
+			matches: (data, action) => {
+				const legacyAction = LEGACY_ACTION_MAP[action];
+				return legacy.matches(data, legacyAction);
+			},
+		};
+	}
+
+	return {
+		matches: (data, action) => matchesDefaultAction(data, action, api.matchesKey),
+	};
+}
+
+export function getSettingsKeybindings(): SettingsKeybindings {
+	return createSettingsKeybindings(PiTui as CompatibleApi);
+}

--- a/packages/sub-core/src/ui/settings-list.ts
+++ b/packages/sub-core/src/ui/settings-list.ts
@@ -2,11 +2,11 @@ import type { Component, SettingItem, SettingsListTheme } from "@mariozechner/pi
 import {
 	Input,
 	fuzzyFilter,
-	getEditorKeybindings,
 	truncateToWidth,
 	visibleWidth,
 	wrapTextWithAnsi,
 } from "@mariozechner/pi-tui";
+import { getSettingsKeybindings } from "./keybindings.js";
 
 export interface SettingsListOptions {
 	enableSearch?: boolean;
@@ -170,7 +170,7 @@ export class SettingsList implements Component {
 			return;
 		}
 
-		const kb = getEditorKeybindings();
+		const kb = getSettingsKeybindings();
 		const displayItems = this.searchEnabled ? this.filteredItems : this.items;
 
 		if (kb.matches(data, "selectUp")) {

--- a/packages/sub-core/src/utils.ts
+++ b/packages/sub-core/src/utils.ts
@@ -2,7 +2,7 @@
  * Utility functions for the sub-bar extension
  */
 
-import type { Dependencies } from "./types.js";
+import type { Dependencies, RateWindow } from "./types.js";
 import { MODEL_MULTIPLIERS } from "./config.js";
 
 // Only allow simple CLI names (no spaces/paths) to avoid unsafe command execution.
@@ -63,6 +63,42 @@ export function normalizeTokens(value: string): string[] {
 		.trim()
 		.split(" ")
 		.filter(Boolean);
+}
+
+/**
+ * Reorder usage windows so those matching the active model come first.
+ * A window matches when every model-ID token appears in the window label
+ * AND the model tokens form a strict majority of the label tokens.
+ * The majority check prevents a short model name (e.g. "gpt-5.3") from
+ * falsely matching a longer, more specific label (e.g. "GPT-5.3-Codex-Spark 5h").
+ * Non-matching windows keep their original relative order.
+ */
+export function prioritizeWindowsForModel(
+	windows: RateWindow[],
+	model?: { id?: string } | null,
+): RateWindow[] {
+	if (!model?.id || windows.length <= 1) return windows;
+
+	const modelTokens = normalizeTokens(model.id);
+	if (modelTokens.length === 0) return windows;
+
+	const matched: RateWindow[] = [];
+	const rest: RateWindow[] = [];
+
+	for (const window of windows) {
+		const labelTokens = normalizeTokens(window.label);
+		const isMatch = modelTokens.every((token) => labelTokens.includes(token))
+			&& modelTokens.length * 2 > labelTokens.length;
+		if (isMatch) {
+			matched.push(window);
+		} else {
+			rest.push(window);
+		}
+	}
+
+	if (matched.length === 0 || matched.length === windows.length) return windows;
+
+	return [...matched, ...rest];
 }
 
 // Pre-computed token entries for model multiplier matching

--- a/packages/sub-core/test/all.test.ts
+++ b/packages/sub-core/test/all.test.ts
@@ -1,5 +1,6 @@
 import "./detection.test.js";
 import "./providers.test.js";
+import "./prioritize.test.js";
 import "./controller.test.js";
 import "./cache.test.js";
 import "./lock.test.js";

--- a/packages/sub-core/test/all.test.ts
+++ b/packages/sub-core/test/all.test.ts
@@ -5,3 +5,4 @@ import "./controller.test.js";
 import "./cache.test.js";
 import "./lock.test.js";
 import "./status.test.js";
+import "./keybindings.test.js";

--- a/packages/sub-core/test/keybindings.test.ts
+++ b/packages/sub-core/test/keybindings.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createSettingsKeybindings } from "../src/ui/keybindings.js";
+
+test("settings keybindings prefer editor keybindings when available", () => {
+	const kb = createSettingsKeybindings({
+		getEditorKeybindings: () => ({
+			matches: (data, action) => data === "X" && action === "selectDown",
+		}),
+		getKeybindings: () => ({
+			matches: () => {
+				throw new Error("legacy keybindings should not be used when editor keybindings exist");
+			},
+		}),
+	});
+
+	assert.equal(kb.matches("X", "selectDown"), true);
+	assert.equal(kb.matches("X", "selectUp"), false);
+});
+
+test("settings keybindings map actions to legacy keybinding IDs", () => {
+	const seen: string[] = [];
+	const kb = createSettingsKeybindings({
+		getKeybindings: () => ({
+			matches: (_data, action) => {
+				seen.push(action);
+				return action === "tui.select.down";
+			},
+		}),
+	});
+
+	assert.equal(kb.matches("ignored", "selectDown"), true);
+	assert.equal(kb.matches("ignored", "cursorLeft"), false);
+	assert.deepEqual(seen, ["tui.select.down", "tui.editor.cursorLeft"]);
+});
+
+test("settings keybindings fallback uses matchesKey helper when no keybinding manager exists", () => {
+	const kb = createSettingsKeybindings({
+		matchesKey: (data, key) => data === `<<${key}>>`,
+	});
+
+	assert.equal(kb.matches("<<up>>", "selectUp"), true);
+	assert.equal(kb.matches("<<down>>", "selectDown"), true);
+	assert.equal(kb.matches("<<left>>", "cursorLeft"), true);
+	assert.equal(kb.matches("<<enter>>", "selectConfirm"), true);
+	assert.equal(kb.matches("<<escape>>", "selectCancel"), true);
+	assert.equal(kb.matches("<<right>>", "cursorLeft"), false);
+});
+
+test("settings keybindings fallback handles raw escape sequences", () => {
+	const kb = createSettingsKeybindings({});
+
+	assert.equal(kb.matches("\u001b[A", "selectUp"), true);
+	assert.equal(kb.matches("\u001b[B", "selectDown"), true);
+	assert.equal(kb.matches("\u001b[D", "cursorLeft"), true);
+	assert.equal(kb.matches("\u001b[C", "cursorRight"), true);
+	assert.equal(kb.matches("\r", "selectConfirm"), true);
+	assert.equal(kb.matches("\u001b", "selectCancel"), true);
+});

--- a/packages/sub-core/test/prioritize.test.ts
+++ b/packages/sub-core/test/prioritize.test.ts
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { RateWindow } from "../src/types.js";
+import { prioritizeWindowsForModel } from "../src/utils.js";
+
+function window(label: string, usedPercent = 0): RateWindow {
+	return { label, usedPercent };
+}
+
+test("codex spark windows are moved before general windows", () => {
+	const windows = [
+		window("5h", 0),
+		window("Week", 1),
+		window("GPT-5.3-Codex-Spark 5h", 2),
+		window("GPT-5.3-Codex-Spark Week", 3),
+	];
+
+	const result = prioritizeWindowsForModel(windows, { id: "gpt-5.3-codex-spark" });
+
+	assert.deepEqual(
+		result.map((w) => w.label),
+		["GPT-5.3-Codex-Spark 5h", "GPT-5.3-Codex-Spark Week", "5h", "Week"],
+	);
+});
+
+test("antigravity current model window is moved first", () => {
+	const windows = [
+		window("Gemini 2.5 Pro"),
+		window("Gemini 3 Flash"),
+		window("Gemini 3 Pro"),
+		window("Gemini 3.5 Flash"),
+	];
+
+	const result = prioritizeWindowsForModel(windows, { id: "gemini-3-pro" });
+
+	assert.deepEqual(
+		result.map((w) => w.label),
+		["Gemini 3 Pro", "Gemini 2.5 Pro", "Gemini 3 Flash", "Gemini 3.5 Flash"],
+	);
+});
+
+test("returns original array when no windows match the model", () => {
+	const windows = [window("5h"), window("Week")];
+
+	const result = prioritizeWindowsForModel(windows, { id: "claude-3.5-sonnet" });
+
+	assert.equal(result, windows);
+});
+
+test("returns original array when all windows match", () => {
+	const windows = [
+		window("GPT-5.3-Codex-Spark 5h"),
+		window("GPT-5.3-Codex-Spark Week"),
+	];
+
+	const result = prioritizeWindowsForModel(windows, { id: "gpt-5.3-codex-spark" });
+
+	assert.equal(result, windows);
+});
+
+test("non-spark codex model does not match spark windows", () => {
+	const windows = [
+		window("5h", 0),
+		window("Week", 1),
+		window("GPT-5.3-Codex-Spark 5h", 2),
+		window("GPT-5.3-Codex-Spark Week", 3),
+	];
+
+	const result = prioritizeWindowsForModel(windows, { id: "gpt-5.3" });
+
+	assert.equal(result, windows);
+});
+
+test("returns original array when model is absent", () => {
+	const windows = [window("5h"), window("Week")];
+
+	assert.equal(prioritizeWindowsForModel(windows, undefined), windows);
+	assert.equal(prioritizeWindowsForModel(windows, null), windows);
+	assert.equal(prioritizeWindowsForModel(windows, { id: undefined }), windows);
+	assert.equal(prioritizeWindowsForModel(windows, { id: "" }), windows);
+});


### PR DESCRIPTION
## Summary
- include the Codex Spark quota ordering fix from #54 (credit: @dnouri)
- fix settings submenu navigation crash on older Pi runtimes by supporting both legacy (`getKeybindings`) and newer (`getEditorKeybindings`) `@mariozechner/pi-tui` APIs
- add a release changeset to bump all packages to **1.5.0** in lockstep:
  - `@marckrenn/pi-sub-bar`
  - `@marckrenn/pi-sub-core`
  - `@marckrenn/pi-sub-shared`
  - `@marckrenn/pi-sub-status`

## Validation
- `npm run check --workspaces --if-present`
- `npm run test --workspaces --if-present`

## Tracking
Fixes #53

Closes #53
