### PR TITLE
feat(sub-core): add MiniMax Token Plan provider

### DIFF
--- a/.changeset/minimax-provider.md
+++ b/.changeset/minimax-provider.md
@@ -1,0 +1,8 @@
+---
+"@marckrenn/pi-sub-core": minor
+"@marckrenn/pi-sub-shared": minor
+---
+
+Add MiniMax Token Plan usage provider
+
+Fetches 5-hour rolling window and weekly quota from the MiniMax open platform API (`api.minimax.io`). Credentials are resolved from `MINIMAX_API_KEY` / `MINIMAX_TOKEN` env vars or `~/.pi/agent/auth.json` under the `minimax` key.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6819,11 +6819,11 @@
     },
     "packages/sub-bar": {
       "name": "@marckrenn/pi-sub-bar",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@marckrenn/pi-sub-core": "^1.3.0",
-        "@marckrenn/pi-sub-shared": "^1.3.0"
+        "@marckrenn/pi-sub-core": "^1.5.0",
+        "@marckrenn/pi-sub-shared": "^1.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6836,10 +6836,10 @@
     },
     "packages/sub-core": {
       "name": "@marckrenn/pi-sub-core",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@marckrenn/pi-sub-shared": "^1.3.0"
+        "@marckrenn/pi-sub-shared": "^1.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6852,18 +6852,18 @@
     },
     "packages/sub-shared": {
       "name": "@marckrenn/pi-sub-shared",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "devDependencies": {
         "typescript": "^5.8.0"
       }
     },
     "packages/sub-status": {
       "name": "@marckrenn/pi-sub-status",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@marckrenn/pi-sub-core": "^1.3.0",
-        "@marckrenn/pi-sub-shared": "^1.3.0"
+        "@marckrenn/pi-sub-core": "^1.5.0",
+        "@marckrenn/pi-sub-shared": "^1.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/sub-core/README.md
+++ b/packages/sub-core/README.md
@@ -100,6 +100,7 @@ Legacy cache files next to the extension entry or in the agent root are migrated
 | OpenAI Codex | Primary/secondary windows | ✅ | Credits not yet supported (PRs welcome!) |
 | AWS Kiro | Credits | - | Credits not yet supported (PRs welcome!) |
 | z.ai | Tokens/monthly limits | - | API quota limits |
+| MiniMax | 5h/Week windows | - | Token Plan API key required |
 
 ## Development
 

--- a/packages/sub-core/src/providers/impl/minimax.ts
+++ b/packages/sub-core/src/providers/impl/minimax.ts
@@ -1,0 +1,115 @@
+/**
+ * MiniMax usage provider
+ */
+
+import * as path from "node:path";
+import type { Dependencies, RateWindow, UsageSnapshot } from "../../types.js";
+import { BaseProvider } from "../../provider.js";
+import { noCredentials, fetchFailed, httpError } from "../../errors.js";
+import { formatReset, createTimeoutController } from "../../utils.js";
+import { API_TIMEOUT_MS } from "../../config.js";
+
+const USAGE_URL = "https://api.minimax.io/v1/api/openplatform/coding_plan/remains";
+
+// MiniMax-AI/MiniMax-M2#99: despite the name, `*_usage_count` fields contain
+// *remaining* quota, not consumed usage. We derive consumed = total - remaining.
+// When the upstream fix lands, change this to: return fieldValue;
+function toConsumed(total: number, fieldValue: number): number {
+	return total - fieldValue;
+}
+
+function loadMiniMaxApiKey(deps: Dependencies): string | undefined {
+	const envKey = (deps.env.MINIMAX_API_KEY || deps.env.MINIMAX_TOKEN)?.trim();
+	if (envKey) return envKey;
+
+	const authPath = path.join(deps.homedir(), ".pi", "agent", "auth.json");
+	try {
+		if (deps.fileExists(authPath)) {
+			const auth = JSON.parse(deps.readFile(authPath)!);
+			const entry = auth["minimax"];
+			if (entry?.key) return String(entry.key);
+			if (entry?.access) return String(entry.access);
+		}
+	} catch {
+	}
+
+	return undefined;
+}
+
+interface ModelRemains {
+	model_name: string;
+	current_interval_total_count: number;
+	current_interval_usage_count: number; // see toConsumed()
+	remains_time: number;                 // ms until 5h window resets
+	current_weekly_total_count?: number;
+	current_weekly_usage_count?: number;  // see toConsumed()
+	weekly_end_time?: number;             // unix ms of weekly reset
+}
+
+export class MiniMaxProvider extends BaseProvider {
+	readonly name = "minimax" as const;
+	readonly displayName = "MiniMax";
+
+	hasCredentials(deps: Dependencies): boolean {
+		return Boolean(loadMiniMaxApiKey(deps));
+	}
+
+	async fetchUsage(deps: Dependencies): Promise<UsageSnapshot> {
+		const apiKey = loadMiniMaxApiKey(deps);
+		if (!apiKey) {
+			return this.emptySnapshot(noCredentials());
+		}
+
+		const { controller, clear } = createTimeoutController(API_TIMEOUT_MS);
+
+		try {
+			const res = await deps.fetch(USAGE_URL, {
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					Accept: "application/json",
+				},
+				signal: controller.signal,
+			});
+			clear();
+
+			if (!res.ok) {
+				return this.emptySnapshot(httpError(res.status));
+			}
+
+			const data = (await res.json()) as { model_remains?: ModelRemains[] };
+			const model = data.model_remains?.find((m) => m.model_name.toLowerCase().includes("minimax-m"));
+			if (!model) {
+				return this.snapshot({ windows: [] });
+			}
+
+			const windows: RateWindow[] = [];
+
+			const total5h = model.current_interval_total_count;
+			if (total5h > 0) {
+				const resetAt = new Date(Date.now() + model.remains_time);
+				windows.push({
+					label: "5h",
+					usedPercent: Math.round((toConsumed(total5h, model.current_interval_usage_count) / total5h) * 100),
+					resetDescription: formatReset(resetAt),
+					resetAt: resetAt.toISOString(),
+				});
+			}
+
+			const totalWeek = model.current_weekly_total_count ?? 0;
+			if (totalWeek > 0 && model.weekly_end_time) {
+				const resetAt = new Date(model.weekly_end_time);
+				windows.push({
+					label: "Week",
+					usedPercent: Math.round((toConsumed(totalWeek, model.current_weekly_usage_count ?? 0) / totalWeek) * 100),
+					resetDescription: formatReset(resetAt),
+					resetAt: resetAt.toISOString(),
+				});
+			}
+
+			return this.snapshot({ windows });
+		} catch {
+			clear();
+			return this.emptySnapshot(fetchFailed());
+		}
+	}
+}

--- a/packages/sub-core/src/providers/registry.ts
+++ b/packages/sub-core/src/providers/registry.ts
@@ -9,6 +9,7 @@ export { AntigravityProvider } from "./impl/antigravity.js";
 export { CodexProvider } from "./impl/codex.js";
 export { KiroProvider } from "./impl/kiro.js";
 export { ZaiProvider } from "./impl/zai.js";
+export { MiniMaxProvider } from "./impl/minimax.js";
 
 import type { Dependencies, ProviderName } from "../types.js";
 import type { UsageProvider } from "../provider.js";
@@ -20,6 +21,7 @@ import { AntigravityProvider } from "./impl/antigravity.js";
 import { CodexProvider } from "./impl/codex.js";
 import { KiroProvider } from "./impl/kiro.js";
 import { ZaiProvider } from "./impl/zai.js";
+import { MiniMaxProvider } from "./impl/minimax.js";
 
 const PROVIDER_FACTORIES: Record<ProviderName, () => UsageProvider> = {
 	anthropic: () => new AnthropicProvider(),
@@ -29,6 +31,7 @@ const PROVIDER_FACTORIES: Record<ProviderName, () => UsageProvider> = {
 	codex: () => new CodexProvider(),
 	kiro: () => new KiroProvider(),
 	zai: () => new ZaiProvider(),
+	minimax: () => new MiniMaxProvider(),
 };
 
 /**

--- a/packages/sub-core/test/providers.test.ts
+++ b/packages/sub-core/test/providers.test.ts
@@ -7,6 +7,7 @@ import { AntigravityProvider } from "../src/providers/impl/antigravity.js";
 import { CodexProvider } from "../src/providers/impl/codex.js";
 import { KiroProvider } from "../src/providers/impl/kiro.js";
 import { ZaiProvider } from "../src/providers/impl/zai.js";
+import { MiniMaxProvider } from "../src/providers/impl/minimax.js";
 import { createDeps, createJsonResponse, getAuthPath } from "./helpers.js";
 import type { UsageSnapshot } from "../src/types.js";
 
@@ -382,4 +383,127 @@ test("zai reports api errors and parses limits", async () => {
 	const usage = await provider.fetchUsage(okDeps);
 	assertWindow(usage, "Tokens");
 	assertWindow(usage, "Monthly");
+});
+
+// MiniMax tests
+
+const MINIMAX_RESPONSE = {
+	model_remains: [
+		{
+			model_name: "MiniMax-M*",
+			current_interval_total_count: 4500,
+			current_interval_usage_count: 4195, // remaining, not consumed
+			remains_time: 7_200_000,            // 2 hours in ms
+			current_weekly_total_count: 45_000,
+			current_weekly_usage_count: 41_898, // remaining, not consumed
+			weekly_end_time: Date.now() + 6 * 24 * 60 * 60 * 1000,
+		},
+	],
+};
+
+test("minimax reads key from MINIMAX_API_KEY env var", async () => {
+	const provider = new MiniMaxProvider();
+	let authorization: string | undefined;
+
+	const { deps } = createDeps({
+		env: { MINIMAX_API_KEY: "env-key" },
+		fetch: async (_url, init) => {
+			authorization = (init as any)?.headers?.Authorization;
+			return createJsonResponse(MINIMAX_RESPONSE);
+		},
+	});
+
+	await provider.fetchUsage(deps);
+	assert.equal(authorization, "Bearer env-key");
+});
+
+test("minimax reads key from auth.json", async () => {
+	const provider = new MiniMaxProvider();
+	let authorization: string | undefined;
+
+	const { deps, files } = createDeps({
+		fetch: async (_url, init) => {
+			authorization = (init as any)?.headers?.Authorization;
+			return createJsonResponse(MINIMAX_RESPONSE);
+		},
+	});
+	withAuth(files, { minimax: { key: "file-key" } }, deps.homedir());
+
+	await provider.fetchUsage(deps);
+	assert.equal(authorization, "Bearer file-key");
+});
+
+test("minimax env key overrides auth.json", async () => {
+	const provider = new MiniMaxProvider();
+	let authorization: string | undefined;
+
+	const { deps, files } = createDeps({
+		env: { MINIMAX_API_KEY: "env-key" },
+		fetch: async (_url, init) => {
+			authorization = (init as any)?.headers?.Authorization;
+			return createJsonResponse(MINIMAX_RESPONSE);
+		},
+	});
+	withAuth(files, { minimax: { key: "file-key" } }, deps.homedir());
+
+	await provider.fetchUsage(deps);
+	assert.equal(authorization, "Bearer env-key");
+});
+
+test("minimax returns no-credentials when key is absent", async () => {
+	const provider = new MiniMaxProvider();
+	const { deps } = createDeps({ fetch: async () => createJsonResponse({}) });
+	assert.equal(provider.hasCredentials(deps), false);
+
+	const usage = await provider.fetchUsage(deps);
+	assert.equal(usage.windows.length, 0);
+	assert.equal(usage.error?.code, "NO_CREDENTIALS");
+});
+
+test("minimax parses 5h and Week windows correctly", async () => {
+	const provider = new MiniMaxProvider();
+	const { deps, files } = createDeps({
+		fetch: async () => createJsonResponse(MINIMAX_RESPONSE),
+	});
+	withAuth(files, { minimax: { key: "token" } }, deps.homedir());
+
+	const usage = await provider.fetchUsage(deps);
+
+	assertWindow(usage, "5h");
+	assertWindow(usage, "Week");
+
+	const fiveHr = usage.windows.find((w) => w.label === "5h")!;
+	// usedPercent = round((4500 - 4195) / 4500 * 100) = round(6.78) = 7
+	assert.equal(fiveHr.usedPercent, 7);
+	assert.ok(fiveHr.resetDescription, "5h window should have a reset description");
+	assert.ok(fiveHr.resetAt, "5h window should have a resetAt timestamp");
+
+	const week = usage.windows.find((w) => w.label === "Week")!;
+	// usedPercent = round((45000 - 41898) / 45000 * 100) = round(6.89) = 7
+	assert.equal(week.usedPercent, 7);
+	assert.ok(week.resetDescription, "Week window should have a reset description");
+});
+
+test("minimax returns fetch-failed on HTTP error", async () => {
+	const provider = new MiniMaxProvider();
+	const { deps, files } = createDeps({
+		fetch: async () => createJsonResponse({}, { ok: false, status: 429 }),
+	});
+	withAuth(files, { minimax: { key: "token" } }, deps.homedir());
+
+	const usage = await provider.fetchUsage(deps);
+	assert.equal(usage.windows.length, 0);
+	assert.equal(usage.error?.code, "HTTP_ERROR");
+});
+
+test("minimax returns empty windows when response has no text model entry", async () => {
+	const provider = new MiniMaxProvider();
+	const { deps, files } = createDeps({
+		fetch: async () => createJsonResponse({ model_remains: [] }),
+	});
+	withAuth(files, { minimax: { key: "token" } }, deps.homedir());
+
+	const usage = await provider.fetchUsage(deps);
+	assert.equal(usage.windows.length, 0);
+	assert.equal(usage.error, undefined); // credentials were fine, model just not in plan
 });

--- a/packages/sub-shared/index.ts
+++ b/packages/sub-shared/index.ts
@@ -2,7 +2,7 @@
  * Shared types and metadata for sub-* extensions.
  */
 
-export const PROVIDERS = ["anthropic", "copilot", "gemini", "antigravity", "codex", "kiro", "zai"] as const;
+export const PROVIDERS = ["anthropic", "copilot", "gemini", "antigravity", "codex", "kiro", "zai", "minimax"] as const;
 
 export type ProviderName = (typeof PROVIDERS)[number];
 
@@ -73,6 +73,7 @@ export interface CoreProviderSettingsMap {
 	codex: CoreProviderSettings;
 	kiro: CoreProviderSettings;
 	zai: CoreProviderSettings;
+	minimax: CoreProviderSettings;
 }
 
 export interface BehaviorSettings {
@@ -193,6 +194,10 @@ export const PROVIDER_METADATA: Record<ProviderName, ProviderMetadata> = {
 	zai: {
 		displayName: "z.ai",
 		detection: { providerTokens: ["zai", "z.ai", "xai"], modelTokens: [] },
+	},
+	minimax: {
+		displayName: "MiniMax",
+		detection: { providerTokens: ["minimax"], modelTokens: ["minimax"] },
 	},
 };
 


### PR DESCRIPTION
Adds MiniMax as a usage provider in `sub-core` and `sub-shared`.

**What it does**

Fetches the Token Plan quota from `https://api.minimax.io/v1/api/openplatform/coding_plan/remains` and exposes two windows: `5h` (rolling five-hour window) and `Week` (weekly quota).

**Credential resolution**

Checks `MINIMAX_API_KEY`, then `MINIMAX_TOKEN`, then `~/.pi/agent/auth.json` under `minimax.key` or `minimax.access` — the same order used by all other providers.

**API quirk**

Despite their names, `current_interval_usage_count` and `current_weekly_usage_count` hold *remaining* quota, not consumed usage ([MiniMax-AI/MiniMax-M2#99](https://github.com/MiniMax-AI/MiniMax-M2/issues/99)). A `toConsumed()` helper derives `consumed = total - remaining`. When the upstream fix lands, changing `return total - fieldValue` to `return fieldValue` is the only edit needed.

**Files changed**

- `packages/sub-shared/index.ts` — adds `minimax` to `PROVIDERS`, `PROVIDER_METADATA`, and `CoreProviderSettingsMap`
- `packages/sub-core/src/providers/impl/minimax.ts` — new provider
- `packages/sub-core/src/providers/registry.ts` — registers `MiniMaxProvider`
- `packages/sub-core/test/providers.test.ts` — 7 tests: credential loading, window parsing, HTTP error, missing model entry
- `packages/sub-core/README.md` — adds MiniMax to the provider comparison table
- `.changeset/minimax-provider.md` — minor bump for `sub-core` and `sub-shared`

**Not included**

The `sub-bar` display layer (window visibility, extras, settings UI) is outside this PR's scope.

**Verification**

All 48 tests pass. TypeScript compiles clean in both `sub-core` and `sub-shared`.