### PR TITLE
Add Kimi for Coding usage display support

### DIFF
--- a/packages/sub-bar/src/providers/metadata.ts
+++ b/packages/sub-bar/src/providers/metadata.ts
@@ -137,6 +137,14 @@ const zaiWindowVisible: ProviderMetadata["isWindowVisible"] = (_usage, window, s
 	return true;
 };
 
+const kimiCodingWindowVisible: ProviderMetadata["isWindowVisible"] = (_usage, window, settings, _model) => {
+	if (!settings) return true;
+	const ps = settings.providers["kimi-coding"];
+	if (window.label === "Week") return ps.windows.showWeek;
+	if (window.label === "5h") return ps.windows.show5h;
+	return true;
+};
+
 const anthropicExtras: ProviderMetadata["getExtras"] = (usage, settings) => {
 	const extras: UsageExtra[] = [];
 	const showExtraWindow = settings?.providers.anthropic.windows.showExtra ?? true;
@@ -195,5 +203,9 @@ export const PROVIDER_METADATA: Record<ProviderName, ProviderMetadata> = {
 	zai: {
 		...BASE_METADATA.zai,
 		isWindowVisible: zaiWindowVisible,
+	},
+	"kimi-coding": {
+		...BASE_METADATA["kimi-coding"],
+		isWindowVisible: kimiCodingWindowVisible,
 	},
 };

--- a/packages/sub-bar/src/providers/settings.ts
+++ b/packages/sub-bar/src/providers/settings.ts
@@ -14,6 +14,7 @@ import type {
 	CodexProviderSettings,
 	KiroProviderSettings,
 	ZaiProviderSettings,
+	KimiCodingProviderSettings,
 } from "../settings-types.js";
 
 function buildBaseProviderItems(ps: BaseProviderSettings): SettingItem[] {
@@ -225,6 +226,26 @@ export function buildProviderSettingsItems(settings: Settings, provider: Provide
 		);
 	}
 
+	if (provider === "kimi-coding") {
+		const kimiSettings = ps as KimiCodingProviderSettings;
+		items.push(
+			{
+				id: "showWeek",
+				label: "Show Week Window",
+				currentValue: kimiSettings.windows.showWeek ? "on" : "off",
+				values: ["on", "off"],
+				description: "Show the weekly usage window.",
+			},
+			{
+				id: "show5h",
+				label: "Show 5h Window",
+				currentValue: kimiSettings.windows.show5h ? "on" : "off",
+				values: ["on", "off"],
+				description: "Show the 5-hour usage window.",
+			},
+		);
+	}
+
 	return items;
 }
 
@@ -351,6 +372,18 @@ export function applyProviderSettingsChange(
 				break;
 			case "showMonthly":
 				zaiSettings.windows.showMonthly = value === "on";
+				break;
+		}
+	}
+
+	if (provider === "kimi-coding") {
+		const kimiSettings = ps as KimiCodingProviderSettings;
+		switch (id) {
+			case "showWeek":
+				kimiSettings.windows.showWeek = value === "on";
+				break;
+			case "show5h":
+				kimiSettings.windows.show5h = value === "on";
 				break;
 		}
 	}

--- a/packages/sub-bar/src/settings-types.ts
+++ b/packages/sub-bar/src/settings-types.ts
@@ -274,6 +274,13 @@ export interface ZaiProviderSettings extends BaseProviderSettings {
 	};
 }
 
+export interface KimiCodingProviderSettings extends BaseProviderSettings {
+	windows: {
+		showWeek: boolean;
+		show5h: boolean;
+	};
+}
+
 export interface ProviderSettingsMap {
 	anthropic: AnthropicProviderSettings;
 	copilot: CopilotProviderSettings;
@@ -282,6 +289,7 @@ export interface ProviderSettingsMap {
 	codex: CodexProviderSettings;
 	kiro: KiroProviderSettings;
 	zai: ZaiProviderSettings;
+	"kimi-coding": KimiCodingProviderSettings;
 }
 
 export type { BehaviorSettings, CoreSettings } from "@marckrenn/pi-sub-shared";
@@ -486,6 +494,13 @@ export function getDefaultSettings(): Settings {
 				windows: {
 					showTokens: true,
 					showMonthly: true,
+				},
+			},
+			"kimi-coding": {
+				showStatus: true,
+				windows: {
+					showWeek: true,
+					show5h: true,
 				},
 			},
 		},

--- a/packages/sub-core/README.md
+++ b/packages/sub-core/README.md
@@ -100,6 +100,7 @@ Legacy cache files next to the extension entry or in the agent root are migrated
 | OpenAI Codex | Primary/secondary windows | ✅ | Credits not yet supported (PRs welcome!) |
 | AWS Kiro | Credits | - | Credits not yet supported (PRs welcome!) |
 | z.ai | Tokens/monthly limits | - | API quota limits |
+| Kimi for Coding | Week + 5h rolling windows | - | OAuth; tested with `pi-provider-kimi-code` |
 
 ## Development
 
@@ -115,7 +116,7 @@ Manual paths/symlinks still work for local development as documented above.
 
 ### Tested providers
 
-Tested so far: Anthropic (Claude), OpenAI Codex, GitHub Copilot. Other providers are implemented but not yet verified in production.
+Tested so far: Anthropic (Claude), OpenAI Codex, GitHub Copilot, Kimi for Coding. Other providers are implemented but not yet verified in production.
 
 ### Adding a Provider
 

--- a/packages/sub-core/src/providers/impl/kimi-coding.ts
+++ b/packages/sub-core/src/providers/impl/kimi-coding.ts
@@ -1,0 +1,124 @@
+/**
+ * Kimi for Coding usage provider
+ */
+
+import * as path from "node:path";
+import type { Dependencies, RateWindow, UsageSnapshot } from "../../types.js";
+import { BaseProvider } from "../../provider.js";
+import { noCredentials, fetchFailed, httpError } from "../../errors.js";
+import { formatReset, createTimeoutController } from "../../utils.js";
+import { API_TIMEOUT_MS } from "../../config.js";
+
+/**
+ * Load Kimi for Coding token from various sources
+ */
+function loadKimiCodingToken(deps: Dependencies): string | undefined {
+	// Explicit override via env var
+	const envToken = deps.env.KIMI_CODING_OAUTH_TOKEN?.trim();
+	if (envToken) return envToken;
+
+	// Try pi auth.json next
+	const piAuthPath = path.join(deps.homedir(), ".pi", "agent", "auth.json");
+	try {
+		if (deps.fileExists(piAuthPath)) {
+			const data = JSON.parse(deps.readFile(piAuthPath) ?? "{}");
+			if (data["kimi-coding"]?.access) return data["kimi-coding"].access;
+		}
+	} catch {
+		// Ignore parse errors
+	}
+
+	return undefined;
+}
+
+interface KimiLimitDetail {
+	limit?: string;
+	used?: string;
+	remaining?: string;
+	resetTime?: string;
+}
+
+interface KimiRateLimit {
+	window?: {
+		duration?: number;
+		timeUnit?: string;
+	};
+	detail?: KimiLimitDetail;
+}
+
+interface KimiUsageResponse {
+	usage?: KimiLimitDetail;
+	limits?: KimiRateLimit[];
+}
+
+function parseDetailToWindow(label: string, detail: KimiLimitDetail | undefined): RateWindow | undefined {
+	if (!detail) return undefined;
+	const limit = parseFloat(detail.limit ?? "0");
+	const used = parseFloat(detail.used ?? "0");
+	if (limit <= 0) return undefined;
+	const resetAt = detail.resetTime ? new Date(detail.resetTime) : undefined;
+	return {
+		label,
+		usedPercent: (used / limit) * 100,
+		resetDescription: resetAt ? formatReset(resetAt) : undefined,
+		resetAt: resetAt?.toISOString(),
+	};
+}
+
+export class KimiCodingProvider extends BaseProvider {
+	readonly name = "kimi-coding" as const;
+	readonly displayName = "Kimi for Coding";
+
+	hasCredentials(deps: Dependencies): boolean {
+		return Boolean(loadKimiCodingToken(deps));
+	}
+
+	async fetchUsage(deps: Dependencies): Promise<UsageSnapshot> {
+		const token = loadKimiCodingToken(deps);
+		if (!token) {
+			return this.emptySnapshot(noCredentials());
+		}
+
+		const { controller, clear } = createTimeoutController(API_TIMEOUT_MS);
+
+		try {
+			const res = await deps.fetch("https://api.kimi.com/coding/v1/usages", {
+				method: "GET",
+				headers: {
+					Authorization: `Bearer ${token}`,
+					Accept: "application/json",
+				},
+				signal: controller.signal,
+			});
+			clear();
+
+			if (!res.ok) {
+				return this.emptySnapshot(httpError(res.status));
+			}
+
+			const data = (await res.json()) as KimiUsageResponse;
+			const windows: RateWindow[] = [];
+
+			// 5h rolling window from limits — search for the 300-minute window
+			const limits = data.limits ?? [];
+			const fiveHourLimit = limits.find(
+				(l) => l.window?.duration === 300 && l.window?.timeUnit === "TIME_UNIT_MINUTE"
+			);
+			const fiveHourWindow = parseDetailToWindow("5h", fiveHourLimit?.detail);
+			if (fiveHourWindow) {
+				windows.push(fiveHourWindow);
+			}
+
+			// Week window from top-level usage detail
+			const weekWindow = parseDetailToWindow("Week", data.usage);
+			if (weekWindow) {
+				windows.push(weekWindow);
+			}
+
+			return this.snapshot({ windows });
+		} catch {
+			clear();
+			return this.emptySnapshot(fetchFailed());
+		}
+	}
+}

--- a/packages/sub-core/src/providers/impl/kimi-coding.ts
+++ b/packages/sub-core/src/providers/impl/kimi-coding.ts
@@ -10,19 +10,28 @@ import { formatReset, createTimeoutController } from "../../utils.js";
 import { API_TIMEOUT_MS } from "../../config.js";
 
 /**
- * Load Kimi for Coding token from various sources
+ * Load Kimi for Coding token from various sources.
+ *
+ * Supports both pi-mono's auth.json format (`{ type: "api_key", key: "..." }`)
+ * and legacy OAuth format (`{ access: "..." }`), plus environment variables.
  */
 function loadKimiCodingToken(deps: Dependencies): string | undefined {
-	// Explicit override via env var
-	const envToken = deps.env.KIMI_CODING_OAUTH_TOKEN?.trim();
+	// pi-mono convention
+	const envToken = deps.env.KIMI_API_KEY?.trim();
 	if (envToken) return envToken;
+
+	// Legacy pi-sub override (keep for backward compat)
+	const legacyEnvToken = deps.env.KIMI_CODING_OAUTH_TOKEN?.trim();
+	if (legacyEnvToken) return legacyEnvToken;
 
 	// Try pi auth.json next
 	const piAuthPath = path.join(deps.homedir(), ".pi", "agent", "auth.json");
 	try {
 		if (deps.fileExists(piAuthPath)) {
 			const data = JSON.parse(deps.readFile(piAuthPath) ?? "{}");
-			if (data["kimi-coding"]?.access) return data["kimi-coding"].access;
+			const entry = data["kimi-coding"];
+			if (entry?.access) return entry.access;
+			if (entry?.key) return entry.key;
 		}
 	} catch {
 		// Ignore parse errors

--- a/packages/sub-core/src/providers/registry.ts
+++ b/packages/sub-core/src/providers/registry.ts
@@ -9,6 +9,7 @@ export { AntigravityProvider } from "./impl/antigravity.js";
 export { CodexProvider } from "./impl/codex.js";
 export { KiroProvider } from "./impl/kiro.js";
 export { ZaiProvider } from "./impl/zai.js";
+export { KimiCodingProvider } from "./impl/kimi-coding.js";
 
 import type { Dependencies, ProviderName } from "../types.js";
 import type { UsageProvider } from "../provider.js";
@@ -20,6 +21,7 @@ import { AntigravityProvider } from "./impl/antigravity.js";
 import { CodexProvider } from "./impl/codex.js";
 import { KiroProvider } from "./impl/kiro.js";
 import { ZaiProvider } from "./impl/zai.js";
+import { KimiCodingProvider } from "./impl/kimi-coding.js";
 
 const PROVIDER_FACTORIES: Record<ProviderName, () => UsageProvider> = {
 	anthropic: () => new AnthropicProvider(),
@@ -29,6 +31,7 @@ const PROVIDER_FACTORIES: Record<ProviderName, () => UsageProvider> = {
 	codex: () => new CodexProvider(),
 	kiro: () => new KiroProvider(),
 	zai: () => new ZaiProvider(),
+	"kimi-coding": () => new KimiCodingProvider(),
 };
 
 /**

--- a/packages/sub-core/test/providers.test.ts
+++ b/packages/sub-core/test/providers.test.ts
@@ -7,6 +7,7 @@ import { AntigravityProvider } from "../src/providers/impl/antigravity.js";
 import { CodexProvider } from "../src/providers/impl/codex.js";
 import { KiroProvider } from "../src/providers/impl/kiro.js";
 import { ZaiProvider } from "../src/providers/impl/zai.js";
+import { KimiCodingProvider } from "../src/providers/impl/kimi-coding.js";
 import { createDeps, createJsonResponse, getAuthPath } from "./helpers.js";
 import type { UsageSnapshot } from "../src/types.js";
 
@@ -382,4 +383,93 @@ test("zai reports api errors and parses limits", async () => {
 	const usage = await provider.fetchUsage(okDeps);
 	assertWindow(usage, "Tokens");
 	assertWindow(usage, "Monthly");
+});
+
+test("kimi-coding reads token from KIMI_CODING_OAUTH_TOKEN env var", async () => {
+	const provider = new KimiCodingProvider();
+	let authorization: string | undefined;
+
+	const { deps } = createDeps({
+		env: { KIMI_CODING_OAUTH_TOKEN: "env-token" },
+		fetch: async (_url, init) => {
+			authorization = (init as any)?.headers?.Authorization;
+			return createJsonResponse({ usage: { limit: "100", used: "10" } });
+		},
+	});
+
+	await provider.fetchUsage(deps);
+	assert.equal(authorization, "Bearer env-token");
+});
+
+test("kimi-coding env token overrides auth.json", async () => {
+	const provider = new KimiCodingProvider();
+	let authorization: string | undefined;
+
+	const { deps, files } = createDeps({
+		env: { KIMI_CODING_OAUTH_TOKEN: "env-token" },
+		fetch: async (_url, init) => {
+			authorization = (init as any)?.headers?.Authorization;
+			return createJsonResponse({ usage: { limit: "100", used: "10" } });
+		},
+	});
+	withAuth(files, { "kimi-coding": { access: "file-token" } }, deps.homedir());
+
+	await provider.fetchUsage(deps);
+	assert.equal(authorization, "Bearer env-token");
+});
+
+test("kimi-coding parses week and 5h windows", async () => {
+	const provider = new KimiCodingProvider();
+	const { deps, files } = createDeps({
+		fetch: async () => createJsonResponse({
+			usage: { limit: "2048", used: "214", remaining: "1834", resetTime: new Date(Date.now() + 86400_000).toISOString() },
+			limits: [{
+				window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" },
+				detail: { limit: "200", used: "139", remaining: "61", resetTime: new Date(Date.now() + 3600_000).toISOString() },
+			}],
+		}),
+	});
+	withAuth(files, { "kimi-coding": { access: "token" } }, deps.homedir());
+
+	const usage = await provider.fetchUsage(deps);
+	assertWindow(usage, "Week");
+	assertWindow(usage, "5h");
+	assert.equal(usage.windows.find((w) => w.label === "Week")?.usedPercent, (214 / 2048) * 100);
+	assert.equal(usage.windows.find((w) => w.label === "5h")?.usedPercent, (139 / 200) * 100);
+});
+
+test("kimi-coding handles missing 5h limit gracefully", async () => {
+	const provider = new KimiCodingProvider();
+	const { deps, files } = createDeps({
+		fetch: async () => createJsonResponse({
+			usage: { limit: "1024", used: "100", remaining: "924" },
+			limits: [],
+		}),
+	});
+	withAuth(files, { "kimi-coding": { access: "token" } }, deps.homedir());
+
+	const usage = await provider.fetchUsage(deps);
+	assertWindow(usage, "Week");
+	assert.equal(usage.windows.length, 1);
+});
+
+test("kimi-coding reports http errors", async () => {
+	const provider = new KimiCodingProvider();
+	const { deps, files } = createDeps({
+		fetch: async () => createJsonResponse({}, { ok: false, status: 401 }),
+	});
+	withAuth(files, { "kimi-coding": { access: "token" } }, deps.homedir());
+
+	const usage = await provider.fetchUsage(deps);
+	assert.equal(usage.error?.code, "HTTP_ERROR");
+});
+
+test("kimi-coding reports no credentials", async () => {
+	const provider = new KimiCodingProvider();
+	const { deps } = createDeps({
+		fetch: async () => createJsonResponse({ usage: {} }),
+	});
+
+	const usage = await provider.fetchUsage(deps);
+	assert.equal(usage.error?.code, "NO_CREDENTIALS");
 });

--- a/packages/sub-core/test/providers.test.ts
+++ b/packages/sub-core/test/providers.test.ts
@@ -464,6 +464,55 @@ test("kimi-coding reports http errors", async () => {
 	assert.equal(usage.error?.code, "HTTP_ERROR");
 });
 
+test("kimi-coding reads token from KIMI_API_KEY env var (pi-mono convention)", async () => {
+	const provider = new KimiCodingProvider();
+	let authorization: string | undefined;
+
+	const { deps } = createDeps({
+		env: { KIMI_API_KEY: "env-token" },
+		fetch: async (_url, init) => {
+			authorization = (init as any)?.headers?.Authorization;
+			return createJsonResponse({ usage: { limit: "100", used: "10" } });
+		},
+	});
+
+	await provider.fetchUsage(deps);
+	assert.equal(authorization, "Bearer env-token");
+});
+
+test("kimi-coding reads token from pi-mono auth.json format", async () => {
+	const provider = new KimiCodingProvider();
+	let authorization: string | undefined;
+
+	const { deps, files } = createDeps({
+		fetch: async (_url, init) => {
+			authorization = (init as any)?.headers?.Authorization;
+			return createJsonResponse({ usage: { limit: "100", used: "10" } });
+		},
+	});
+	withAuth(files, { "kimi-coding": { type: "api_key", key: "file-token" } }, deps.homedir());
+
+	await provider.fetchUsage(deps);
+	assert.equal(authorization, "Bearer file-token");
+});
+
+test("kimi-coding KIMI_API_KEY env var overrides auth.json", async () => {
+	const provider = new KimiCodingProvider();
+	let authorization: string | undefined;
+
+	const { deps, files } = createDeps({
+		env: { KIMI_API_KEY: "env-token" },
+		fetch: async (_url, init) => {
+			authorization = (init as any)?.headers?.Authorization;
+			return createJsonResponse({ usage: { limit: "100", used: "10" } });
+		},
+	});
+	withAuth(files, { "kimi-coding": { type: "api_key", key: "file-token" } }, deps.homedir());
+
+	await provider.fetchUsage(deps);
+	assert.equal(authorization, "Bearer env-token");
+});
+
 test("kimi-coding reports no credentials", async () => {
 	const provider = new KimiCodingProvider();
 	const { deps } = createDeps({

--- a/packages/sub-shared/index.ts
+++ b/packages/sub-shared/index.ts
@@ -2,7 +2,7 @@
  * Shared types and metadata for sub-* extensions.
  */
 
-export const PROVIDERS = ["anthropic", "copilot", "gemini", "antigravity", "codex", "kiro", "zai"] as const;
+export const PROVIDERS = ["anthropic", "copilot", "gemini", "antigravity", "codex", "kiro", "zai", "kimi-coding"] as const;
 
 export type ProviderName = (typeof PROVIDERS)[number];
 
@@ -73,6 +73,7 @@ export interface CoreProviderSettingsMap {
 	codex: CoreProviderSettings;
 	kiro: CoreProviderSettings;
 	zai: CoreProviderSettings;
+	"kimi-coding": CoreProviderSettings;
 }
 
 export interface BehaviorSettings {
@@ -193,6 +194,10 @@ export const PROVIDER_METADATA: Record<ProviderName, ProviderMetadata> = {
 	zai: {
 		displayName: "z.ai",
 		detection: { providerTokens: ["zai", "z.ai", "xai"], modelTokens: [] },
+	},
+	"kimi-coding": {
+		displayName: "Kimi for Coding",
+		detection: { providerTokens: ["kimi"], modelTokens: ["kimi-for-coding"] },
 	},
 };
 


### PR DESCRIPTION
sub-bar and sub-status now show your weekly request quota and 5-hour rolling rate limit when using Kimi for Coding.  The data is fetched from the official api.kimi.com/coding/v1/usages endpoint using the OAuth token stored in ~/.pi/agent/auth.json.

You can toggle the Week and 5h windows independently in the sub-bar settings, just like the other providers.