### PR TITLE
fix(sub-core): respect cache TTL on turn_end and tool_result (fixes #58)

### DIFF
--- a/.changeset/sub-core-turn-end-ttl.md
+++ b/.changeset/sub-core-turn-end-ttl.md
@@ -1,0 +1,26 @@
+---
+"@marckrenn/pi-sub-core": patch
+---
+
+`turn_end` and `tool_result` no longer pass `force: true` to `refresh` /
+`refreshStatus`. The forced refresh bypassed the cache TTL, so an active
+session would hit the upstream `/usage` endpoint on every turn, regardless
+of how recently the cache had been refreshed.
+
+When the upstream endpoint started rate-limiting (anthropic OAuth
+`/usage` returns 429s under load, especially with multiple `pi`
+instances sharing a session), `fetchWithCache` saw `usage.error`, set
+`shouldCache = false`, and never updated `fetchedAt`. Subsequent
+`turn_end`s kept retrying the rate-limited endpoint and discarding the
+results, so the cache stayed stuck on the last good entry — eventually
+older than the 60s TTL — and `sub-core:update-all` started filtering
+the current provider out of `entries`. UI clients then saw the current
+provider missing and cleared their displays.
+
+Removing `force: true` lets the existing `behavior.refreshInterval`
+(default 60s) and `behavior.minRefreshInterval` (default 10s) gates do
+their job: turns that arrive faster than the configured TTL reuse the
+cache instead of re-hammering the API. `model_select` keeps `force: true`
+because switching providers always needs fresh data.
+
+Fixes #58.

--- a/packages/sub-core/index.ts
+++ b/packages/sub-core/index.ts
@@ -475,15 +475,15 @@ export default function createExtension(pi: ExtensionAPI, deps: Dependencies = c
 
 	pi.on("tool_result", async (_event, ctx) => {
 		if (settings.behavior.refreshOnToolResult) {
-			await refresh(ctx, { force: true });
+			await refresh(ctx);
 		}
 		if (settings.statusRefresh.refreshOnToolResult) {
-			await refreshStatus(ctx, { force: true });
+			await refreshStatus(ctx);
 		}
 	});
 
 	pi.on("turn_end", async (_event, ctx) => {
-		await refresh(ctx, { force: true });
+		await refresh(ctx);
 	});
 
 	pi.on("session_switch", async (_event, ctx) => {

--- a/packages/sub-core/test/all.test.ts
+++ b/packages/sub-core/test/all.test.ts
@@ -2,6 +2,7 @@ import "./detection.test.js";
 import "./providers.test.js";
 import "./prioritize.test.js";
 import "./controller.test.js";
+import "./extension.test.js";
 import "./cache.test.js";
 import "./lock.test.js";
 import "./status.test.js";

--- a/packages/sub-core/test/extension.test.ts
+++ b/packages/sub-core/test/extension.test.ts
@@ -1,0 +1,233 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { ExtensionAPI, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import createExtension from '../index.js';
+import { CACHE_PATH, clearCache } from '../src/cache.js';
+import { SETTINGS_PATH } from '../src/settings.js';
+import { getStorage, setStorage, type StorageAdapter } from '../src/storage.js';
+import { createDeps, getAuthPath } from './helpers.js';
+
+interface PiHarness {
+	pi: ExtensionAPI;
+	emitLifecycle: (event: string, ctx: ExtensionContext) => Promise<void>;
+}
+
+/**
+ * Build a minimal ExtensionAPI mock that captures lifecycle handlers
+ * (`pi.on(event, handler)`) and exposes them via `emitLifecycle` for
+ * deterministic invocation in tests.
+ */
+function createPiHarness(): PiHarness {
+	const lifecycle = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>();
+	const eventListeners = new Map<string, Array<(payload: unknown) => unknown>>();
+
+	const events = {
+		on(event: string, handler: (payload: unknown) => unknown) {
+			const list = eventListeners.get(event) ?? [];
+			list.push(handler);
+			eventListeners.set(event, list);
+		},
+		emit(event: string, payload?: unknown) {
+			for (const handler of eventListeners.get(event) ?? []) {
+				handler(payload);
+			}
+		},
+	};
+
+	const pi = {
+		events,
+		on(event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) {
+			const list = lifecycle.get(event) ?? [];
+			list.push(handler);
+			lifecycle.set(event, list);
+		},
+		registerCommand: () => {},
+		registerTool: () => {},
+		registerShortcut: () => {},
+		registerFlag: () => {},
+		getFlag: () => undefined,
+		registerMessageRenderer: () => {},
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		appendEntry: () => {},
+		setSessionName: () => {},
+		getSessionName: () => undefined,
+		setLabel: () => {},
+		exec: async () => ({ code: 0, stdout: '', stderr: '' }),
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		setActiveTools: () => {},
+		setModel: async () => true,
+		getThinkingLevel: () => 'high',
+		setThinkingLevel: () => {},
+		registerProvider: () => {},
+	} as unknown as ExtensionAPI;
+
+	return {
+		pi,
+		async emitLifecycle(event, ctx) {
+			for (const handler of lifecycle.get(event) ?? []) {
+				await handler({ type: event }, ctx);
+			}
+		},
+	};
+}
+
+function createMemoryStorage(): { storage: StorageAdapter; files: Map<string, string> } {
+	const files = new Map<string, string>();
+	const storage: StorageAdapter = {
+		readFile: (filePath) => files.get(filePath),
+		writeFile: (filePath, contents) => {
+			files.set(filePath, contents);
+		},
+		writeFileExclusive: (filePath, contents) => {
+			if (files.has(filePath)) return false;
+			files.set(filePath, contents);
+			return true;
+		},
+		exists: (filePath) => files.has(filePath),
+		removeFile: (filePath) => {
+			files.delete(filePath);
+		},
+		ensureDir: () => {},
+	};
+	return { storage, files };
+}
+
+function createCtx(): ExtensionContext {
+	return {
+		ui: {
+			select: async () => undefined,
+			confirm: async () => false,
+			input: async () => undefined,
+			notify: () => {},
+			setStatus: () => {},
+			setWorkingMessage: () => {},
+			setWidget: () => {},
+			setFooter: () => {},
+			setHeader: () => {},
+			setTitle: () => {},
+			custom: async () => undefined,
+			setEditorText: () => {},
+		},
+		hasUI: false,
+		cwd: '/tmp/project',
+		sessionManager: {} as ExtensionContext['sessionManager'],
+		modelRegistry: {} as ExtensionContext['modelRegistry'],
+		model: { provider: 'anthropic', id: 'claude-opus-4-7' } as ExtensionContext['model'],
+		isIdle: () => true,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => '',
+	} as ExtensionContext;
+}
+
+function resetGlobal(): void {
+	const g = globalThis as typeof globalThis & { __piSubCore?: { active: boolean } };
+	g.__piSubCore = undefined;
+}
+
+/**
+ * Regression for marckrenn/pi-sub#58.
+ *
+ * Before the fix, `turn_end` and `tool_result` (with `refreshOnToolResult` enabled)
+ * called `refresh(ctx, { force: true })`. That bypassed the cache TTL and triggered
+ * an upstream fetch on every turn, hammering rate-limited endpoints (e.g. anthropic
+ * OAuth `/usage`) and, when the endpoint started returning 429, leaving the cache
+ * stuck because `fetchWithCache` refuses to write entries with errors.
+ *
+ * With the fix, both handlers call `refresh(ctx)` without `force`, so the existing
+ * `behavior.refreshInterval` (60s) and `behavior.minRefreshInterval` (10s) gates
+ * correctly suppress redundant network calls when the cache is fresh.
+ */
+test('turn_end and tool_result do not bypass the cache TTL when the entry is fresh', async () => {
+	const originalStorage = getStorage();
+	const { storage, files } = createMemoryStorage();
+	setStorage(storage);
+	clearCache();
+	resetGlobal();
+
+	try {
+		const home = '/home/test';
+		let fetchCount = 0;
+		const { deps, files: depFiles } = createDeps({
+			fetch: async () => {
+				fetchCount += 1;
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ({}),
+				} as Response;
+			},
+			homedir: home,
+		});
+		// anthropic provider reads ~/.pi/agent/auth.json under `anthropic.access`.
+		depFiles.set(getAuthPath(home), JSON.stringify({ anthropic: { access: 'token' } }));
+
+		// Pre-populate the cache: 30s old. That's past the 10s minRefreshInterval but
+		// well within the 60s ttl. Without `force`, fetchUsageForProvider must return
+		// the cached value; with `force: true` (the bug) it bypasses the ttl and fetches.
+		const fetchedAt = Date.now() - 30_000;
+		files.set(
+			CACHE_PATH,
+			JSON.stringify({
+				anthropic: {
+					fetchedAt,
+					statusFetchedAt: fetchedAt,
+					usage: {
+						provider: 'anthropic',
+						displayName: 'Anthropic (Claude)',
+						windows: [
+							{ label: '5h', usedPercent: 12, resetDescription: '4h' },
+							{ label: 'Week', usedPercent: 25, resetDescription: '3d' },
+						],
+					},
+					status: { indicator: 'none' },
+				},
+			}),
+		);
+
+		// Enable refresh on tool result so the tool_result handler actually calls refresh.
+		files.set(
+			SETTINGS_PATH,
+			JSON.stringify({
+				version: 3,
+				behavior: { refreshOnToolResult: true, refreshInterval: 60, minRefreshInterval: 10 },
+				statusRefresh: { refreshOnToolResult: true, refreshInterval: 60, minRefreshInterval: 10 },
+				providers: { anthropic: { enabled: 'on', fetchStatus: false } },
+			}),
+		);
+
+		const harness = createPiHarness();
+		createExtension(harness.pi, deps);
+
+		const ctx = createCtx();
+		await harness.emitLifecycle('session_start', ctx);
+		// session_start emits with skipFetch:true, so it should not hit the network.
+		assert.equal(fetchCount, 0, 'session_start should never fetch');
+
+		await harness.emitLifecycle('turn_end', ctx);
+		assert.equal(
+			fetchCount,
+			0,
+			'turn_end must respect cache TTL and not refetch when the entry is fresh',
+		);
+
+		await harness.emitLifecycle('tool_result', ctx);
+		assert.equal(
+			fetchCount,
+			0,
+			'tool_result must respect cache TTL and not refetch when the entry is fresh',
+		);
+
+		// Cleanup so the global guard, intervals and watchers do not leak across tests.
+		await harness.emitLifecycle('session_shutdown', ctx);
+	} finally {
+		resetGlobal();
+		setStorage(originalStorage);
+		clearCache();
+	}
+});


### PR DESCRIPTION
Fixes #58.

## Problem

`turn_end` calls `refresh(ctx, { force: true })` unconditionally, and `tool_result` does the same when `refreshOnToolResult` is enabled. `force: true` bypasses both the cache check in `fetchUsageForProvider`:

```ts
if (!options?.force) {
    const cachedUsage = await getCachedData(provider, ttlMs, cache);
    if (cachedUsage) return cached;
}
```

…and the pre-fetch check in `fetchWithCache`:

```ts
if (!forceRefresh) {
    const cached = await getCachedData(provider, ttlMs);
    if (cached) return cached;
}
```

So every turn end triggers a real network call against the upstream usage endpoint, regardless of how fresh the cache is.

## Why this is a problem

Under load — particularly with multiple `pi` instances sharing the cache (e.g. one per tmux pane, all on `claude-opus-4-7`) — this is enough to push anthropic's OAuth `/usage` endpoint into 429 territory. The chain that follows:

1. `fetchUsage` returns `emptySnapshot(httpError(429))` (windows = `[]`, `error` set).
2. `fetchWithCache` evaluates `hasError = true` → `shouldCache = false` → cache is **not** updated, `fetchedAt` stays old.
3. The previous successful entry remains in the cache but its age keeps growing.
4. Once age passes `behavior.refreshInterval` (60s), `onCacheSnapshot`'s TTL filter drops the entry from `sub-core:update-all`'s `entries`:

   ```ts
   for (const provider of settings.providerOrder) {
       const entry = cache[provider];
       if (!entry || !entry.usage) continue;
       if (now - entry.fetchedAt >= ttlMs) continue;   // <- current provider gone
       entries.push({ provider, usage });
   }
   ```

5. UI clients see the current provider missing from `entries` and clear their displays. The bars come back when the rate limit clears and a refresh succeeds, then disappear again on the next stretch of 429s — the disappear/reappear flicker that triggered the upstream report I'm forwarding.

## Fix

Drop `force: true` from `turn_end` and `tool_result`. The existing TTL gates already handle the cadence:

- `behavior.minRefreshInterval` (10s) keeps fetches from being too rapid.
- `behavior.refreshInterval` (60s) bounds staleness.
- Per-instance `setupRefreshInterval` ticks every 10s and triggers a real refresh once 60s have elapsed.

`model_select` keeps `force: true` because switching providers always needs fresh data.

This is exactly the diff proposed in the issue body, as filed by Ryan Willging — credit goes to that report. I'm packaging it up with a regression test and a changeset.

## Tradeoff

Display can lag up to `refreshInterval` seconds (default 60s) after a turn ends, which is the intended TTL behavior. Better than indefinite staleness from silent rate-limit failures.

## Regression test

`packages/sub-core/test/extension.test.ts` loads the extension with a mock `pi` lifecycle, pre-populates a fresh cache entry (~30s old: past `minRefreshInterval` but within `refreshInterval`), and asserts that `turn_end` and `tool_result` do **not** invoke `deps.fetch`.

I verified the test fails on `main` (with `force: true` still in place, `fetchCount` becomes 1 after `turn_end`) and passes after the fix.

## Validation locally

```
$ npm run check -w @marckrenn/pi-sub-core
  tsc --noEmit
$ npm test -w @marckrenn/pi-sub-core
  ℹ tests 42 / pass 42 / fail 0
```

## Changeset

`@marckrenn/pi-sub-core` patch (the lockstep `fixed` group propagates to `pi-sub-bar` and `pi-sub-shared`).

## Note about the cosmetic side

I deliberately did NOT run `npm run format`. On a fresh checkout it rewrites the entire repo from double quotes to single quotes (the codebase is currently double-quoted but the prettier config asks for single). Happy to ship a separate format-only PR if that's wanted, but mixing it into this fix would make the diff impossible to review.
