### PR TITLE
feat(openrouter): Add openrouter provider

### DIFF
--- a/.changeset/clever-carrots-build.md
+++ b/.changeset/clever-carrots-build.md
@@ -1,0 +1,7 @@
+---
+'@marckrenn/pi-sub-shared': major
+'@marckrenn/pi-sub-core': major
+'@marckrenn/pi-sub-bar': major
+---
+
+Add Openrouter provider

--- a/packages/sub-bar/src/providers/metadata.ts
+++ b/packages/sub-bar/src/providers/metadata.ts
@@ -137,6 +137,18 @@ const zaiWindowVisible: ProviderMetadata["isWindowVisible"] = (_usage, window, s
 	return true;
 };
 
+const openrouterWindowVisible: ProviderMetadata["isWindowVisible"] = (_usage, window, settings, _model) => {
+	if (!settings) return true;
+	const ps = settings.providers.openrouter;
+	if (window.label === "Credits") return ps.windows.showCredits;
+	return true;
+};
+
+function formatUsd(value: number, digits: number): string {
+	const safeValue = Object.is(value, -0) ? 0 : value;
+	return `$${safeValue.toFixed(digits)}`;
+}
+
 const anthropicExtras: ProviderMetadata["getExtras"] = (usage, settings) => {
 	const extras: UsageExtra[] = [];
 	const showExtraWindow = settings?.providers.anthropic.windows.showExtra ?? true;
@@ -162,6 +174,34 @@ const copilotExtras: ProviderMetadata["getExtras"] = (usage, settings, modelId) 
 		}
 		extras.push({ label: multiplierStr });
 	}
+	return extras;
+};
+
+const openrouterExtras: ProviderMetadata["getExtras"] = (usage, settings) => {
+	const extras: UsageExtra[] = [];
+	const showRemainingCredit = settings?.providers.openrouter.showRemainingCredit ?? true;
+	const showCreditBreakdown = settings?.providers.openrouter.showCreditBreakdown ?? false;
+	if (!showRemainingCredit) return extras;
+
+	const remaining = usage.creditRemaining;
+	if (remaining === undefined) return extras;
+
+	const remainingLabel = formatUsd(remaining, remaining >= 1 ? 2 : 4);
+	if (!showCreditBreakdown) {
+		extras.push({ label: `${remainingLabel} left` });
+		return extras;
+	}
+
+	const total = usage.creditTotal;
+	const used = usage.creditUsage;
+	if (total === undefined || used === undefined) {
+		extras.push({ label: `${remainingLabel} left` });
+		return extras;
+	}
+
+	const usedLabel = formatUsd(used, 2);
+	const totalLabel = formatUsd(total, 2);
+	extras.push({ label: `${remainingLabel} left (${usedLabel}/${totalLabel} used)` });
 	return extras;
 };
 
@@ -195,5 +235,10 @@ export const PROVIDER_METADATA: Record<ProviderName, ProviderMetadata> = {
 	zai: {
 		...BASE_METADATA.zai,
 		isWindowVisible: zaiWindowVisible,
+	},
+	openrouter: {
+		...BASE_METADATA.openrouter,
+		isWindowVisible: openrouterWindowVisible,
+		getExtras: openrouterExtras,
 	},
 };

--- a/packages/sub-bar/src/providers/settings.ts
+++ b/packages/sub-bar/src/providers/settings.ts
@@ -14,6 +14,7 @@ import type {
 	CodexProviderSettings,
 	KiroProviderSettings,
 	ZaiProviderSettings,
+	OpenRouterProviderSettings,
 } from "../settings-types.js";
 
 function buildBaseProviderItems(ps: BaseProviderSettings): SettingItem[] {
@@ -225,6 +226,33 @@ export function buildProviderSettingsItems(settings: Settings, provider: Provide
 		);
 	}
 
+	if (provider === "openrouter") {
+		const openRouterSettings = ps as OpenRouterProviderSettings;
+		items.push(
+			{
+				id: "showCredits",
+				label: "Show Credits Window",
+				currentValue: openRouterSettings.windows.showCredits ? "on" : "off",
+				values: ["on", "off"],
+				description: "Show the credits usage window.",
+			},
+			{
+				id: "showRemainingCredit",
+				label: "Show Remaining Credit",
+				currentValue: openRouterSettings.showRemainingCredit ? "on" : "off",
+				values: ["on", "off"],
+				description: "Show the remaining OpenRouter credit line.",
+			},
+			{
+				id: "showCreditBreakdown",
+				label: "Show Credit Breakdown",
+				currentValue: openRouterSettings.showCreditBreakdown ? "on" : "off",
+				values: ["on", "off"],
+				description: "Append used/total credit details next to remaining credit.",
+			},
+		);
+	}
+
 	return items;
 }
 
@@ -351,6 +379,21 @@ export function applyProviderSettingsChange(
 				break;
 			case "showMonthly":
 				zaiSettings.windows.showMonthly = value === "on";
+				break;
+		}
+	}
+
+	if (provider === "openrouter") {
+		const openRouterSettings = ps as OpenRouterProviderSettings;
+		switch (id) {
+			case "showCredits":
+				openRouterSettings.windows.showCredits = value === "on";
+				break;
+			case "showRemainingCredit":
+				openRouterSettings.showRemainingCredit = value === "on";
+				break;
+			case "showCreditBreakdown":
+				openRouterSettings.showCreditBreakdown = value === "on";
 				break;
 		}
 	}

--- a/packages/sub-bar/src/settings-types.ts
+++ b/packages/sub-bar/src/settings-types.ts
@@ -274,6 +274,14 @@ export interface ZaiProviderSettings extends BaseProviderSettings {
 	};
 }
 
+export interface OpenRouterProviderSettings extends BaseProviderSettings {
+	showRemainingCredit: boolean;
+	showCreditBreakdown: boolean;
+	windows: {
+		showCredits: boolean;
+	};
+}
+
 export interface ProviderSettingsMap {
 	anthropic: AnthropicProviderSettings;
 	copilot: CopilotProviderSettings;
@@ -282,6 +290,7 @@ export interface ProviderSettingsMap {
 	codex: CodexProviderSettings;
 	kiro: KiroProviderSettings;
 	zai: ZaiProviderSettings;
+	openrouter: OpenRouterProviderSettings;
 }
 
 export type { BehaviorSettings, CoreSettings } from "@marckrenn/pi-sub-shared";
@@ -486,6 +495,14 @@ export function getDefaultSettings(): Settings {
 				windows: {
 					showTokens: true,
 					showMonthly: true,
+				},
+			},
+			openrouter: {
+				showStatus: false,
+				showRemainingCredit: true,
+				showCreditBreakdown: false,
+				windows: {
+					showCredits: true,
 				},
 			},
 		},

--- a/packages/sub-bar/test/providers.test.ts
+++ b/packages/sub-bar/test/providers.test.ts
@@ -14,6 +14,17 @@ function buildCopilotUsage(): UsageSnapshot {
 	};
 }
 
+function buildOpenRouterUsage(): UsageSnapshot {
+	return {
+		provider: "openrouter",
+		displayName: "OpenRouter Credits",
+		windows: [],
+		creditTotal: 20,
+		creditUsage: 7.25,
+		creditRemaining: 12.75,
+	};
+}
+
 test("copilot extras include multiplier and requests left", () => {
 	const settings = getDefaultSettings();
 	settings.providers.copilot.showMultiplier = true;
@@ -39,4 +50,29 @@ test("copilot extras respect toggle settings", () => {
 	assert.equal(withMultiplierOnly.length, 1);
 	assert.ok(withMultiplierOnly[0].label.includes("Model multiplier: 0x"));
 	assert.ok(!withMultiplierOnly[0].label.includes("req. left"));
+});
+
+test("openrouter extras show remaining credit by default", () => {
+	const settings = getDefaultSettings();
+
+	const extras = getUsageExtras(buildOpenRouterUsage(), settings);
+	assert.equal(extras.length, 1);
+	assert.equal(extras[0].label, "$12.75 left");
+});
+
+test("openrouter extras can include breakdown", () => {
+	const settings = getDefaultSettings();
+	settings.providers.openrouter.showCreditBreakdown = true;
+
+	const extras = getUsageExtras(buildOpenRouterUsage(), settings);
+	assert.equal(extras.length, 1);
+	assert.equal(extras[0].label, "$12.75 left ($7.25/$20.00 used)");
+});
+
+test("openrouter extras respect showRemainingCredit toggle", () => {
+	const settings = getDefaultSettings();
+	settings.providers.openrouter.showRemainingCredit = false;
+
+	const extras = getUsageExtras(buildOpenRouterUsage(), settings);
+	assert.equal(extras.length, 0);
 });

--- a/packages/sub-core/README.md
+++ b/packages/sub-core/README.md
@@ -100,6 +100,7 @@ Legacy cache files next to the extension entry or in the agent root are migrated
 | OpenAI Codex | Primary/secondary windows | ✅ | Credits not yet supported (PRs welcome!) |
 | AWS Kiro | Credits | - | Credits not yet supported (PRs welcome!) |
 | z.ai | Tokens/monthly limits | - | API quota limits |
+| OpenRouter | Credits | - | API credits endpoint |
 
 ## Development
 
@@ -115,7 +116,7 @@ Manual paths/symlinks still work for local development as documented above.
 
 ### Tested providers
 
-Tested so far: Anthropic (Claude), OpenAI Codex, GitHub Copilot. Other providers are implemented but not yet verified in production.
+Tested so far: Anthropic (Claude), OpenAI Codex, GitHub Copilot, OpenRouter. Other providers are implemented but not yet verified in production.
 
 ### Adding a Provider
 

--- a/packages/sub-core/src/config.ts
+++ b/packages/sub-core/src/config.ts
@@ -24,6 +24,11 @@ export { MODEL_MULTIPLIERS } from "@marckrenn/pi-sub-shared";
 export const API_TIMEOUT_MS = 5000;
 
 /**
+ * OpenRouter credits endpoint
+ */
+export const OPENROUTER_CREDITS_URL = "https://openrouter.ai/api/v1/credits";
+
+/**
  * Timeout for CLI commands in milliseconds
  */
 export const CLI_TIMEOUT_MS = 10000;

--- a/packages/sub-core/src/providers/impl/openrouter.ts
+++ b/packages/sub-core/src/providers/impl/openrouter.ts
@@ -1,0 +1,115 @@
+/**
+ * OpenRouter usage provider
+ */
+
+import * as path from "node:path";
+import type { Dependencies, RateWindow, UsageSnapshot } from "../../types.js";
+import { BaseProvider } from "../../provider.js";
+import { noCredentials, fetchFailed, httpError, apiError } from "../../errors.js";
+import { createTimeoutController } from "../../utils.js";
+import { API_TIMEOUT_MS, OPENROUTER_CREDITS_URL } from "../../config.js";
+
+interface OpenRouterCreditsResponse {
+	data?: {
+		total_credits?: number;
+		total_usage?: number;
+	};
+}
+
+function normalizeApiKey(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function loadOpenRouterApiKey(deps: Dependencies): string | undefined {
+	const envApiKey = normalizeApiKey(deps.env.OPENROUTER_API_KEY ?? deps.env.OPENROUTER_KEY);
+	if (envApiKey) return envApiKey;
+
+	const authPath = path.join(deps.homedir(), ".pi", "agent", "auth.json");
+	try {
+		if (deps.fileExists(authPath)) {
+			const auth = JSON.parse(deps.readFile(authPath) ?? "{}") as Record<string, unknown>;
+			const openrouterAuth = auth.openrouter as Record<string, unknown> | undefined;
+			return (
+				normalizeApiKey(openrouterAuth?.access)
+				?? normalizeApiKey(openrouterAuth?.key)
+				?? normalizeApiKey(openrouterAuth?.apiKey)
+			);
+		}
+	} catch {
+		// Ignore parse errors
+	}
+
+	return undefined;
+}
+
+function toFiniteNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function clampPercent(value: number): number {
+	return Math.max(0, Math.min(100, value));
+}
+
+export class OpenRouterProvider extends BaseProvider {
+	readonly name = "openrouter" as const;
+	readonly displayName = "OpenRouter";
+
+	hasCredentials(deps: Dependencies): boolean {
+		return Boolean(loadOpenRouterApiKey(deps));
+	}
+
+	async fetchUsage(deps: Dependencies): Promise<UsageSnapshot> {
+		const apiKey = loadOpenRouterApiKey(deps);
+		if (!apiKey) {
+			return this.emptySnapshot(noCredentials());
+		}
+
+		const { controller, clear } = createTimeoutController(API_TIMEOUT_MS);
+
+		try {
+			const res = await deps.fetch(OPENROUTER_CREDITS_URL, {
+				method: "GET",
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					Accept: "application/json",
+				},
+				signal: controller.signal,
+			});
+			clear();
+
+			if (!res.ok) {
+				return this.emptySnapshot(httpError(res.status));
+			}
+
+			const data = (await res.json()) as OpenRouterCreditsResponse;
+			const totalCredits = toFiniteNumber(data.data?.total_credits);
+			const totalUsage = toFiniteNumber(data.data?.total_usage);
+
+			if (totalCredits === undefined || totalUsage === undefined) {
+				return this.emptySnapshot(apiError("Invalid OpenRouter credits response"));
+			}
+
+			const usedPercent = totalCredits > 0
+				? clampPercent((totalUsage / totalCredits) * 100)
+				: 0;
+			const windows: RateWindow[] = [
+				{
+					label: "Credits",
+					usedPercent,
+				},
+			];
+
+			return this.snapshot({
+				windows,
+				creditTotal: totalCredits,
+				creditUsage: totalUsage,
+				creditRemaining: totalCredits - totalUsage,
+			});
+		} catch {
+			clear();
+			return this.emptySnapshot(fetchFailed());
+		}
+	}
+}

--- a/packages/sub-core/src/providers/registry.ts
+++ b/packages/sub-core/src/providers/registry.ts
@@ -9,6 +9,7 @@ export { AntigravityProvider } from "./impl/antigravity.js";
 export { CodexProvider } from "./impl/codex.js";
 export { KiroProvider } from "./impl/kiro.js";
 export { ZaiProvider } from "./impl/zai.js";
+export { OpenRouterProvider } from "./impl/openrouter.js";
 
 import type { Dependencies, ProviderName } from "../types.js";
 import type { UsageProvider } from "../provider.js";
@@ -20,6 +21,7 @@ import { AntigravityProvider } from "./impl/antigravity.js";
 import { CodexProvider } from "./impl/codex.js";
 import { KiroProvider } from "./impl/kiro.js";
 import { ZaiProvider } from "./impl/zai.js";
+import { OpenRouterProvider } from "./impl/openrouter.js";
 
 const PROVIDER_FACTORIES: Record<ProviderName, () => UsageProvider> = {
 	anthropic: () => new AnthropicProvider(),
@@ -29,6 +31,7 @@ const PROVIDER_FACTORIES: Record<ProviderName, () => UsageProvider> = {
 	codex: () => new CodexProvider(),
 	kiro: () => new KiroProvider(),
 	zai: () => new ZaiProvider(),
+	openrouter: () => new OpenRouterProvider(),
 };
 
 /**

--- a/packages/sub-core/test/detection.test.ts
+++ b/packages/sub-core/test/detection.test.ts
@@ -22,3 +22,13 @@ test("detectProviderFromModel handles overlapping provider tokens", () => {
 	const provider = detectProviderFromModel({ provider: "z.ai", id: "model" });
 	assert.equal(provider, "zai");
 });
+
+test("detectProviderFromModel detects openrouter by provider", () => {
+	const provider = detectProviderFromModel({ provider: "openrouter", id: "openrouter/auto" });
+	assert.equal(provider, "openrouter");
+});
+
+test("detectProviderFromModel detects openrouter case-insensitively", () => {
+	const provider = detectProviderFromModel({ provider: "OpenRouter", id: "meta-llama" });
+	assert.equal(provider, "openrouter");
+});

--- a/packages/sub-core/test/providers.test.ts
+++ b/packages/sub-core/test/providers.test.ts
@@ -7,6 +7,7 @@ import { AntigravityProvider } from "../src/providers/impl/antigravity.js";
 import { CodexProvider } from "../src/providers/impl/codex.js";
 import { KiroProvider } from "../src/providers/impl/kiro.js";
 import { ZaiProvider } from "../src/providers/impl/zai.js";
+import { OpenRouterProvider } from "../src/providers/impl/openrouter.js";
 import { createDeps, createJsonResponse, getAuthPath } from "./helpers.js";
 import type { UsageSnapshot } from "../src/types.js";
 
@@ -162,6 +163,84 @@ test("zai reads token from ZAI_API_KEY env var", async () => {
 
 	await provider.fetchUsage(deps);
 	assert.equal(authorization, "Bearer z-token");
+});
+
+test("openrouter reads token from OPENROUTER_API_KEY env var", async () => {
+	const provider = new OpenRouterProvider();
+	let authorization: string | undefined;
+
+	const { deps } = createDeps({
+		env: { OPENROUTER_API_KEY: "or-token" },
+		fetch: async (_url, init) => {
+			authorization = (init as any)?.headers?.Authorization;
+			return createJsonResponse({ data: { total_credits: 10, total_usage: 2 } });
+		},
+	});
+
+	await provider.fetchUsage(deps);
+	assert.equal(authorization, "Bearer or-token");
+});
+
+test("openrouter env token overrides auth.json", async () => {
+	const provider = new OpenRouterProvider();
+	let authorization: string | undefined;
+
+	const { deps, files } = createDeps({
+		env: { OPENROUTER_API_KEY: "env-token" },
+		fetch: async (_url, init) => {
+			authorization = (init as any)?.headers?.Authorization;
+			return createJsonResponse({ data: { total_credits: 10, total_usage: 1 } });
+		},
+	});
+	withAuth(files, { openrouter: { access: "file-token" } }, deps.homedir());
+
+	await provider.fetchUsage(deps);
+	assert.equal(authorization, "Bearer env-token");
+});
+
+test("openrouter parses credits and usage window", async () => {
+	const provider = new OpenRouterProvider();
+	const { deps, files } = createDeps({
+		fetch: async () => createJsonResponse({ data: { total_credits: 20, total_usage: 5 } }),
+	});
+	withAuth(files, { openrouter: { access: "token" } }, deps.homedir());
+
+	const usage = await provider.fetchUsage(deps);
+	assertWindow(usage, "Credits");
+	assert.equal(usage.windows[0]?.usedPercent, 25);
+	assert.equal(usage.creditTotal, 20);
+	assert.equal(usage.creditUsage, 5);
+	assert.equal(usage.creditRemaining, 15);
+});
+
+test("openrouter reports http errors", async () => {
+	const provider = new OpenRouterProvider();
+	const { deps, files } = createDeps({
+		fetch: async () => createJsonResponse({}, { ok: false, status: 401 }),
+	});
+	withAuth(files, { openrouter: { access: "token" } }, deps.homedir());
+
+	const usage = await provider.fetchUsage(deps);
+	assert.equal(usage.error?.code, "HTTP_ERROR");
+});
+
+test("openrouter reports invalid API responses", async () => {
+	const provider = new OpenRouterProvider();
+	const { deps, files } = createDeps({
+		fetch: async () => createJsonResponse({ data: { total_credits: "10" } }),
+	});
+	withAuth(files, { openrouter: { access: "token" } }, deps.homedir());
+
+	const usage = await provider.fetchUsage(deps);
+	assert.equal(usage.error?.code, "API_ERROR");
+});
+
+test("openrouter reports missing credentials", async () => {
+	const provider = new OpenRouterProvider();
+	const { deps } = createDeps();
+
+	const usage = await provider.fetchUsage(deps);
+	assert.equal(usage.error?.code, "NO_CREDENTIALS");
 });
 
 test("copilot handles missing quota snapshots", async () => {

--- a/packages/sub-shared/index.ts
+++ b/packages/sub-shared/index.ts
@@ -2,7 +2,7 @@
  * Shared types and metadata for sub-* extensions.
  */
 
-export const PROVIDERS = ["anthropic", "copilot", "gemini", "antigravity", "codex", "kiro", "zai"] as const;
+export const PROVIDERS = ["anthropic", "copilot", "gemini", "antigravity", "codex", "kiro", "zai", "openrouter"] as const;
 
 export type ProviderName = (typeof PROVIDERS)[number];
 
@@ -32,6 +32,9 @@ export interface UsageSnapshot {
 	requestsSummary?: string;
 	requestsRemaining?: number;
 	requestsEntitlement?: number;
+	creditTotal?: number;
+	creditUsage?: number;
+	creditRemaining?: number;
 }
 
 export type UsageErrorCode =
@@ -73,6 +76,7 @@ export interface CoreProviderSettingsMap {
 	codex: CoreProviderSettings;
 	kiro: CoreProviderSettings;
 	zai: CoreProviderSettings;
+	openrouter: CoreProviderSettings;
 }
 
 export interface BehaviorSettings {
@@ -193,6 +197,10 @@ export const PROVIDER_METADATA: Record<ProviderName, ProviderMetadata> = {
 	zai: {
 		displayName: "z.ai",
 		detection: { providerTokens: ["zai", "z.ai", "xai"], modelTokens: [] },
+	},
+	openrouter: {
+		displayName: "OpenRouter",
+		detection: { providerTokens: ["openrouter"], modelTokens: [] },
 	},
 };
 


### PR DESCRIPTION
- add `openrouter` to shared provider metadata and provider list
- extend `UsageSnapshot` with OpenRouter credit fields: `creditTotal`, `creditUsage`, `creditRemaining`
- add `OPENROUTER_CREDITS_URL` to core config
- implement `OpenRouterProvider` with:
  - env/auth token resolution
  - credits endpoint fetch
  - response validation
  - standard error mapping
- register the provider in the core registry
- add core tests for detection, credentials, parsing, and error cases
- add sub-bar provider integration:
  - credits window visibility toggle
  - remaining credit toggle
  - credit breakdown toggle
  - OpenRouter extras rendering
- add sub-bar tests for OpenRouter extras and toggles
- update sub-core README provider comparison and tested providers