### PR TITLE
fix(kiro): capture stderr output and support YYYY-MM-DD reset date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6819,11 +6819,11 @@
     },
     "packages/sub-bar": {
       "name": "@marckrenn/pi-sub-bar",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@marckrenn/pi-sub-core": "^1.3.0",
-        "@marckrenn/pi-sub-shared": "^1.3.0"
+        "@marckrenn/pi-sub-core": "^1.5.0",
+        "@marckrenn/pi-sub-shared": "^1.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6836,10 +6836,10 @@
     },
     "packages/sub-core": {
       "name": "@marckrenn/pi-sub-core",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@marckrenn/pi-sub-shared": "^1.3.0"
+        "@marckrenn/pi-sub-shared": "^1.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6852,18 +6852,18 @@
     },
     "packages/sub-shared": {
       "name": "@marckrenn/pi-sub-shared",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "devDependencies": {
         "typescript": "^5.8.0"
       }
     },
     "packages/sub-status": {
       "name": "@marckrenn/pi-sub-status",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@marckrenn/pi-sub-core": "^1.3.0",
-        "@marckrenn/pi-sub-shared": "^1.3.0"
+        "@marckrenn/pi-sub-core": "^1.5.0",
+        "@marckrenn/pi-sub-shared": "^1.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/packages/sub-core/src/providers/impl/kiro.ts
+++ b/packages/sub-core/src/providers/impl/kiro.ts
@@ -34,8 +34,8 @@ export class KiroProvider extends BaseProvider {
 				return this.emptySnapshot(notLoggedIn());
 			}
 
-			// Get usage
-			const output = deps.execFileSync(kiroBinary, ["chat", "--no-interactive", "/usage"], {
+			// Get usage (kiro-cli writes to stderr, so redirect via shell)
+			const output = deps.execFileSync("/bin/sh", ["-c", `"${kiroBinary}" chat --no-interactive /usage 2>&1`], {
 				encoding: "utf-8",
 				timeout: CLI_TIMEOUT_MS,
 				env: { ...deps.env, TERM: "xterm-256color" },
@@ -62,11 +62,15 @@ export class KiroProvider extends BaseProvider {
 				}
 			}
 
-			// Parse reset date from "resets on 01/01"
+			// Parse reset date from "resets on 2026-06-01" or "resets on 01/01"
 			let resetsAt: Date | undefined;
-			const resetMatch = stripped.match(/resets on (\d{2}\/\d{2})/);
-			if (resetMatch) {
-				const [month, day] = resetMatch[1].split("/").map(Number);
+			const resetMatchISO = stripped.match(/resets on (\d{4})-(\d{2})-(\d{2})/);
+			const resetMatchSlash = stripped.match(/resets on (\d{2})\/(\d{2})/);
+			if (resetMatchISO) {
+				const [, y, m, d] = resetMatchISO;
+				resetsAt = new Date(parseInt(y), parseInt(m) - 1, parseInt(d));
+			} else if (resetMatchSlash) {
+				const [month, day] = [parseInt(resetMatchSlash[1]), parseInt(resetMatchSlash[2])];
 				const now = new Date();
 				const year = now.getFullYear();
 				resetsAt = new Date(year, month - 1, day);

--- a/packages/sub-core/test/providers.test.ts
+++ b/packages/sub-core/test/providers.test.ts
@@ -317,14 +317,14 @@ test("codex includes additional rate limits for model-specific usage", async () 
 	assertWindow(usage, "GPT-5.3-Codex-Spark Week");
 });
 
-test("kiro parses percentage and reset date", async () => {
+test("kiro parses percentage and reset date (MM/DD)", async () => {
 	const provider = new KiroProvider();
 	const output = "██████ 12%\nresets on 01/01";
 	const { deps } = createDeps({
 		execFileSync: (file: string, args: string[]) => {
 			if (file === "which" && args[0] === "kiro-cli") return "/usr/local/bin/kiro-cli";
 			if (file === "/usr/local/bin/kiro-cli" && args[0] === "whoami") return "user";
-			if (file === "/usr/local/bin/kiro-cli" && args[0] === "chat") return output;
+			if (file === "/bin/sh" && args[0] === "-c") return output;
 			throw new Error(`Unexpected command ${file} ${args.join(" ")}`);
 		},
 	});
@@ -335,6 +335,24 @@ test("kiro parses percentage and reset date", async () => {
 	assert.ok(usage.windows[0]?.resetAt);
 });
 
+test("kiro parses percentage and reset date (YYYY-MM-DD)", async () => {
+	const provider = new KiroProvider();
+	const output = "██████████████████████████████████ 42%\nresets on 2026-06-01";
+	const { deps } = createDeps({
+		execFileSync: (file: string, args: string[]) => {
+			if (file === "which" && args[0] === "kiro-cli") return "/usr/local/bin/kiro-cli";
+			if (file === "/usr/local/bin/kiro-cli" && args[0] === "whoami") return "user";
+			if (file === "/bin/sh" && args[0] === "-c") return output;
+			throw new Error(`Unexpected command ${file} ${args.join(" ")}`);
+		},
+	});
+
+	const usage = await provider.fetchUsage(deps);
+	assertWindow(usage, "Credits");
+	assert.equal(usage.windows[0]?.usedPercent, 42);
+	assert.ok(usage.windows[0]?.resetAt);
+});
+
 test("kiro parses credits when percent is missing", async () => {
 	const provider = new KiroProvider();
 	const output = "(1.5 of 10 covered in plan) resets on 12/31";
@@ -342,7 +360,7 @@ test("kiro parses credits when percent is missing", async () => {
 		execFileSync: (file: string, args: string[]) => {
 			if (file === "which" && args[0] === "kiro-cli") return "/usr/local/bin/kiro-cli";
 			if (file === "/usr/local/bin/kiro-cli" && args[0] === "whoami") return "user";
-			if (file === "/usr/local/bin/kiro-cli" && args[0] === "chat") return output;
+			if (file === "/bin/sh" && args[0] === "-c") return output;
 			throw new Error(`Unexpected command ${file} ${args.join(" ")}`);
 		},
 	});


### PR DESCRIPTION
## Problem

`kiro-cli chat --no-interactive /usage` writes its output to **stderr**, not stdout. Since `execFileSync` only returns stdout, the provider always gets an empty string, causing credits to show as 0%.

Additionally, the reset date regex only matched `MM/DD` format, but kiro-cli now outputs `YYYY-MM-DD` (e.g. `resets on 2026-06-01`).

## Fix

- Redirect stderr to stdout via `/bin/sh -c '... 2>&1'`
- Support both `YYYY-MM-DD` and `MM/DD` reset date formats

## Verified

- Tested locally: credits now correctly show 42% (424/1000) with reset date
- All 42 existing tests pass